### PR TITLE
[modern-tooling] Expand pre-commit root coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -6,7 +6,7 @@ command_line = venv/bin/pytest
 relative_files = True
 
 [report]
-exclude_lines = 
+exclude_lines =
     pragma: no cover
     if TYPE_CHECKING:
     if __name__ == "__main__":

--- a/.flake8
+++ b/.flake8
@@ -15,4 +15,3 @@ extend-ignore =
     I005,
     S101
 radon-max-cc = 10
-    

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,10 @@
-files: (src/|tests/)
+# Keep source-quality hooks scoped to package and test code. Root helper/example
+# files snippets.py and test.py are intentionally outside that legacy lint
+# baseline; setup.py and .vulture.py stay covered by package/repo-specific hooks.
+# Generic config/release hooks still inspect root files such as pyproject.toml,
+# GitHub workflows, pypi.sh, and pre-commit config. Generated architecture SVGs
+# and the example notebook are excluded globally because they are bulky outputs.
+exclude: ^(tests/architecture/.*\.svg|snippets\.ipynb)$
 default_stages: [commit-msg, pre-commit, pre-push]
 repos:
 - hooks:
@@ -7,6 +13,7 @@ repos:
     - '80'
     id: black
     language_version: python3.10
+    files: ^(src|tests)/.*\.py$
   repo: https://github.com/psf/black
   rev: 22.10.0
 - hooks:
@@ -40,6 +47,7 @@ repos:
     - flake8-annotations-complexity
     - flake8-type-checking
     id: flake8
+    files: ^(src|tests)/.*\.py$
   repo: https://github.com/pycqa/flake8
   rev: 6.0.0
 - hooks:
@@ -49,6 +57,7 @@ repos:
   - id: check-case-conflict
   - id: check-docstring-first
   - id: check-executables-have-shebangs
+  - id: check-shebang-scripts-are-executable
   - id: check-json
   - id: check-symlinks
   - id: check-toml
@@ -67,18 +76,22 @@ repos:
     - pandas-stubs
     - types-beautifulsoup4
     id: mypy
+    files: ^src/.*\.py$
   repo: https://github.com/pre-commit/mirrors-mypy
   rev: v0.991
 - hooks:
   - id: darglint
+    files: ^(src|tests)/.*\.py$
   repo: https://github.com/terrencepreilly/darglint
   rev: v1.8.1
 - hooks:
   - id: tryceratops
+    files: ^(src|tests)/.*\.py$
   repo: https://github.com/guilatrova/tryceratops
   rev: v1.1.0
 - hooks:
   - id: pyroma
+    files: ^(pyproject\.toml|setup\.py|README\.md|LICENSE)$
   repo: https://github.com/regebro/pyroma
   rev: 5.0.1
 - hooks:
@@ -89,18 +102,26 @@ repos:
     - --min-confidence
     - '59'
     id: vulture
+    files: ^(src/|setup\.py|\.vulture\.py)
   repo: https://github.com/jendrikseipp/vulture
   rev: v2.6
 - hooks:
   - id: sourcery
     require_serial: true
+    files: ^(src|tests)/.*\.py$
   repo: https://github.com/sourcery-ai/sourcery
   rev: v1.43.0
+- hooks:
+  - id: shellcheck
+    files: ^pypi\.sh$
+  repo: https://github.com/shellcheck-py/shellcheck-py
+  rev: v0.11.0.1
 - hooks:
   - id: pylint
     entry: pylint
     name: pylint
     language: system
+    files: ^(src|tests)/.*\.py$
     types:
       - python
     args:

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,10 +9,10 @@
             "console": "integratedTerminal",
             "cwd": "${workspaceFolder}",
             "args": [
-                "-I"
+                "-I",
                 "-p","eurcad",
                 "-f","ascii",
-                "-t","1-minute-bar-quotes",//"tick-data-quotes",//
+                "-t","1-minute-bar-quotes",
                 "-s","2022-01",
                 "-e","now",
                 "-c","100"

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ The formats available are:
 ##### To download 1-minute-bar-quotes for both metastock and excel
 
 ```sh
-histdatacom -p usdjpy -f metastock excel -s now 
+histdatacom -p usdjpy -f metastock excel -s now
 ```
 
 ---
@@ -342,7 +342,7 @@ options.cpu_utilization = 100
 at present, calling from another script or module is limited to using the `__name__=="__main__"` idiom.
 
 ```python
-if __name__=="__main__": 
+if __name__=="__main__":
    histdatacom(options)
 ```
 
@@ -435,10 +435,10 @@ print(type(data))
 ```txt
 [
   {
-    'timeframe': 'M1', 
-    'pair': 'EURUSD', 
+    'timeframe': 'M1',
+    'pair': 'EURUSD',
     'records': [<histdatacom.records.Record object ...>, ...],
-    'data':    
+    'data':
                     datetime     open     high      low    close  vol
       0       1609711200000  1.22396  1.22396  1.22373  1.22395    0
       1       1609711260000  1.22387  1.22420  1.22385  1.22395    0
@@ -453,12 +453,12 @@ print(type(data))
       484176  1650664680000  1.07980  1.07986  1.07963  1.07963    0
 
       [484177 rows x 6 columns]
-  }, 
+  },
   {
-    'timeframe': 'M1', 
+    'timeframe': 'M1',
     'pair': 'USDCAD',
     'records': [<histdatacom.records.Record object ...>, ...],
-    'data':                
+    'data':
                     datetime     open     high      low    close  vol
       0       1609711200000  1.27136  1.27201  1.27136  1.27201    0
       1       1609711260000  1.27207  1.27241  1.27207  1.27220    0
@@ -507,7 +507,7 @@ M1 EURUSD
 at present, calling from another script or module is limited to using the `__name__=="__main__"` idiom.
 
 ```python
-if __name__=="__main__": 
+if __name__=="__main__":
    histdatacom(options)
 ```
 
@@ -558,7 +558,7 @@ def print_one_polars_frame(pair, start=None, end=None):
 
 def main():
     histdata_symbs = Pairs.list_keys()
-    
+
     # Oanda Symbols:
     oanda_symbs = {"audcad","audchf","audhkd","audjpy","audsgd","audusd","cadhkd","cadjpy","cadsgd",
     "chfhkd","chfjpy","euraud","eurcad","eurchf","eurgbp","eurhkd","eurjpy","eursgd","eurusd","gbpaud",
@@ -574,7 +574,7 @@ def main():
     for pair in pairs_data:
         start = pairs_data[pair]['start']
         end = pairs_data[pair]['end']
-        
+
         import_pair_to_influx(pair, start, end)
 
 if __name__ == '__main__':

--- a/pypi.sh
+++ b/pypi.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 bold=$(tput bold)
 normal=$(tput sgr0)
 
@@ -26,10 +28,11 @@ buildenv()
     echo "${bold}setting up test pip environment${normal}"
     rm -rf ../myproject
     mkdir ../myproject
-    cd ../myproject
+    cd ../myproject || exit
     pwd
     python -m venv venv
     echo "${bold}activating test pip environment${normal}"
+    # shellcheck source=/dev/null
     source venv/bin/activate
     pip install polars
     echo "${bold}test pip environment set up complete.${normal}"
@@ -37,9 +40,10 @@ buildenv()
 
 destroyenv()
 {
-    cd ../histdata.com-tools
+    cd ../histdata.com-tools || exit
     rm -rf ../myproject
     echo "${bold}leaving test pip environment${normal}"
+    # shellcheck source=/dev/null
     source venv/bin/activate
 }
 


### PR DESCRIPTION
## Summary

- Replace the global `src/|tests/` pre-commit matcher with per-hook targeting so root tooling files are checked.
- Add root-oriented coverage for YAML/TOML/JSON, executable shell scripts, ShellCheck on `pypi.sh`, and Pyroma on packaging metadata.
- Document intentional exclusions and clean up root whitespace caught by the now-active generic hooks.
- Fix tracked `.vscode/launch.json` so JSON validation gives useful signal.

## Validation

- `pre-commit run check-yaml --files .github/workflows/ci.yml .github/workflows/release.yml .pre-commit-config.yaml`
- `pre-commit run check-toml --files pyproject.toml`
- `pre-commit run check-json --all-files`
- `pre-commit run shellcheck --files pypi.sh`
- `pre-commit run pyroma --files pyproject.toml setup.py README.md LICENSE`
- `python -m pytest -q`
- `bash pypi.sh build`
- `pre-commit run --all-files` now checks root/tooling surfaces; remaining failures are the existing source lint/type/docstring backlog tracked by the modern-tooling series.

Fixes #99
