### PR TITLE
ci: refresh GitHub Actions pins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,28 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
+  actionlint:
+    name: Lint GitHub Actions workflows
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v7.0.0
+
+      - name: Download actionlint
+        run: |
+          bash <(curl --fail --location --show-error https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) 1.7.12
+        shell: bash
+
+      - name: Check workflow files
+        run: ./actionlint -color
+        shell: bash
+
   test:
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -33,10 +54,10 @@ jobs:
 
     steps:
       - name: Check out source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
@@ -61,10 +82,10 @@ jobs:
 
     steps:
       - name: Check out source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: "3.13"
           cache: pip
@@ -81,7 +102,7 @@ jobs:
         run: python -m twine check dist/*
 
       - name: Upload package artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: histdatacom-dist
           path: dist/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   build:
     name: Build release artifacts
@@ -22,10 +26,10 @@ jobs:
 
     steps:
       - name: Check out source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: "3.13"
           cache: pip
@@ -42,7 +46,7 @@ jobs:
         run: python -m twine check dist/*
 
       - name: Upload release artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: histdatacom-dist
           path: dist/*
@@ -62,10 +66,10 @@ jobs:
 
     steps:
       - name: Download release artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8.0.1
         with:
           name: histdatacom-dist
           path: dist
 
       - name: Publish package distributions
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@v1.14.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,6 +62,10 @@ repos:
   repo: https://github.com/shellcheck-py/shellcheck-py
   rev: v0.11.0.1
 - hooks:
+  - id: actionlint
+  repo: https://github.com/rhysd/actionlint
+  rev: v1.7.12
+- hooks:
   - id: histdatacom
     entry: histdatacom
     language: system

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -32,6 +32,31 @@ signatures, matching the historical release process.
 The CI workflow builds and tests the package on pull requests, pushes to
 `main`, and manual dispatches.
 
+CI also runs `actionlint` against every workflow. The same workflow lint is
+available locally through pre-commit, so workflow syntax and common GitHub
+Actions mistakes are checked before push.
+
+Workflow actions are pinned to current supported releases:
+
+- `actions/checkout@v7.0.0`
+- `actions/setup-python@v6.2.0`
+- `actions/upload-artifact@v7.0.1`
+- `actions/download-artifact@v8.0.1`
+- `pypa/gh-action-pypi-publish@v1.14.0`
+- `rhysd/actionlint@v1.7.12`
+
+The GitHub-maintained Node 24 actions require GitHub Actions Runner
+`v2.327.1` or newer on self-hosted runners. The hosted Ubuntu, macOS, and
+Windows runners used by this project satisfy that requirement. The checkout
+v7 fork-safety defaults only affect `pull_request_target` and `workflow_run`
+triggers; these workflows use `push`, `pull_request`, `workflow_dispatch`, and
+tag push triggers. The artifact v4+ service is intended for GitHub.com hosted
+workflows, which is the supported CI environment for this project.
+
+Pull request CI uses workflow concurrency to cancel stale runs when a branch is
+updated. Release workflow concurrency does not cancel in-progress runs, so a
+manual publish cannot be interrupted by a later tag or dispatch event.
+
 The release workflow builds artifacts on `v*` tags and manual dispatches. It
 does not publish automatically on tag push. Publishing to PyPI through GitHub
 Actions requires a manual workflow dispatch with `publish_to_pypi` enabled.


### PR DESCRIPTION
## Summary
- pin GitHub workflow actions to current supported releases
- add actionlint in CI and pre-commit
- add workflow concurrency while keeping PyPI publishing manual-only
- document runner and release migration constraints

## Validation
- env PATH="$PWD/venv/bin:$PATH" PYTHONNOUSERSITE=1 pre-commit run actionlint --all-files
- env PATH="$PWD/venv/bin:$PATH" PYTHONNOUSERSITE=1 pre-commit run --all-files
- env PATH="$PWD/venv/bin:$PATH" PYTHONNOUSERSITE=1 python -m pytest -q
- env PATH="$PWD/venv/bin:$PATH" PYTHONNOUSERSITE=1 bash pypi.sh build

Fixes #101