### PR TITLE
ci: enforce coverage baseline

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,12 +1,22 @@
 [run]
 branch = True
 concurrency = multiprocessing
-source = src
-command_line = venv/bin/pytest
+source = histdatacom
+command_line = -m pytest
 relative_files = True
 
 [report]
+fail_under = 58.0
+precision = 1
+show_missing = True
+skip_covered = True
 exclude_lines =
     pragma: no cover
     if TYPE_CHECKING:
     if __name__ == "__main__":
+
+[xml]
+output = coverage.xml
+
+[html]
+directory = htmlcov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,8 +67,21 @@ jobs:
           python -m pip install --upgrade pip "setuptools>=77" wheel
           python -m pip install -e ".[pandas,arrow]" pytest pytest-cov
 
-      - name: Run tests
-        run: python -m pytest
+      - name: Run tests with coverage
+        run: python -m pytest --cov=histdatacom --cov-report=term-missing:skip-covered --cov-report=xml --cov-report=html
+
+      - name: Enforce coverage threshold
+        run: python -m coverage report
+
+      - name: Upload coverage reports
+        if: always()
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: coverage-${{ matrix.os }}-py${{ matrix.python-version }}
+          path: |
+            coverage.xml
+            htmlcov/
+          if-no-files-found: warn
 
       - name: Compile source and tests
         run: python -m compileall -q src tests test.py snippets.py

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ output.pstats
 result.json
 out.gv
 htmlcov/
+coverage.xml
 .coverage
 .coverage.*
 

--- a/README.md
+++ b/README.md
@@ -627,6 +627,20 @@ Commitizen, and the local CLI/coverage smoke hooks. The previous flake8 plugin
 stack was intentionally replaced with Ruff so local installs and hook behavior
 do not drift independently.
 
+### Coverage Policy
+
+Coverage is enforced as a conservative total-project ratchet. The initial
+threshold is set in `.coveragerc` from the current baseline so CI catches real
+coverage regressions without blocking modernization work on unrelated low-legacy
+modules. Future test work should raise `fail_under` when the baseline improves;
+do not lower it unless a PR explains the production risk and links the follow-up
+issue.
+
+CI runs pytest through `pytest-cov`, enforces the `.coveragerc` threshold, and
+uploads `coverage.xml` plus the `htmlcov/` report for every Python and OS matrix
+leg. The first-pass gate is total-only. Per-package or domain thresholds belong
+with the broader testing work tracked in issues #9 and #68.
+
 ---
 
 #### Vanilla MacOS and Linux


### PR DESCRIPTION
## Summary
- move coverage execution away from a local venv path and set a CI-safe module command
- add a conservative 58.0% total coverage ratchet in .coveragerc
- run pytest-cov in CI and upload coverage XML/HTML artifacts for each test matrix leg
- document the total-only first-pass policy and link broader test expansion to #9 and #68

## Validation
- env PATH="$PWD/venv/bin:$PATH" PYTHONNOUSERSITE=1 python -m coverage run && python -m coverage report
- env PATH="$PWD/venv/bin:$PATH" PYTHONNOUSERSITE=1 python -m pytest --cov=histdatacom --cov-report=term-missing:skip-covered --cov-report=xml --cov-report=html && python -m coverage report
- env PATH="$PWD/venv/bin:$PATH" PYTHONNOUSERSITE=1 pre-commit run --all-files
- env PATH="$PWD/venv/bin:$PATH" PYTHONNOUSERSITE=1 bash pypi.sh build

Fixes #102
Refs #9
Refs #68