### PR TITLE
ci: add security scanning gates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: America/Chicago
+    open-pull-requests-limit: 5
+    labels:
+      - modern-tooling
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:30"
+      timezone: America/Chicago
+    open-pull-requests-limit: 5
+    labels:
+      - modern-tooling
+    groups:
+      python-packaging:
+        patterns:
+          - "*"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,92 @@
+name: Security
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: "37 9 * * 1"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  dependency-review:
+    name: Review dependency changes
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v7.0.0
+
+      - name: Review dependency changes
+        uses: actions/dependency-review-action@v5.0.0
+        with:
+          fail-on-severity: moderate
+          fail-on-scopes: runtime, development
+
+  python-dependency-audit:
+    name: Audit Python dependencies
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v7.0.0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6.2.0
+        with:
+          python-version: "3.13"
+          cache: pip
+
+      - name: Install audit environment
+        run: |
+          python -m pip install --upgrade pip "setuptools>=77" wheel
+          python -m pip install -e ".[pandas,arrow]"
+          python -m pip install "pip-audit==2.10.1"
+
+      - name: Run pip-audit
+        run: python -m pip_audit --local --strict --format=json --output=pip-audit.json --progress-spinner=off
+
+      - name: Upload pip-audit report
+        if: always()
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: pip-audit-report
+          path: pip-audit.json
+          if-no-files-found: warn
+
+  codeql:
+    name: CodeQL Python analysis
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v7.0.0
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4.36.2
+        with:
+          languages: python
+          build-mode: none
+
+      - name: Analyze with CodeQL
+        uses: github/codeql-action/analyze@v4.36.2
+        with:
+          category: "/language:python"

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ result.json
 out.gv
 htmlcov/
 coverage.xml
+pip-audit.json
 .coverage
 .coverage.*
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -71,3 +71,36 @@ this project:
 
 The `pypi` environment should require manual approval in GitHub before publish
 jobs run.
+
+## Dependency And Security Triage
+
+Dependabot monitors GitHub Actions and Python packaging metadata weekly. Its
+pull requests should run the full CI and security workflows before merge.
+
+The security workflow runs on pull requests, pushes to `main`, manual dispatch,
+and a weekly schedule. It has no publishing permissions. Dependency Review is
+enabled for pull requests on this public repository and fails when dependency
+changes introduce moderate, high, or critical vulnerabilities in runtime or
+development scopes. `pip-audit` installs the package with the pandas and arrow
+optional dependencies, audits the resulting Python environment, and uploads a
+JSON report. CodeQL analyzes the Python source with no build step; it only has
+`security-events: write` so GitHub can receive code-scanning results.
+
+For a published PyPI package, triage vulnerability findings by affected install
+surface:
+
+- Runtime dependencies affect ordinary `pip install histdatacom` users and
+  should be patched with a minimum-version floor or compatible dependency range
+  before publishing a patch release.
+- Optional dependency findings affect users who install extras such as
+  `histdatacom[pandas]` or `histdatacom[arrow]`; patch those ranges and mention
+  the affected extra in release notes.
+- Development and build findings block contributor or release hygiene but do
+  not automatically require a PyPI release unless the vulnerable package is
+  included in built distributions or runtime metadata.
+- Transitive findings should be fixed by raising the direct dependency lower
+  bound when possible. Avoid pinning runtime dependencies more tightly than
+  needed for a library package.
+- If no fixed version exists, keep the finding open, document the exposure and
+  mitigation in the tracking issue, and avoid publishing a release that expands
+  the affected install surface.


### PR DESCRIPTION
## Summary
- add Dependabot updates for GitHub Actions and Python packaging metadata
- add a Security workflow with Dependency Review, pip-audit, and CodeQL Python analysis
- upload pip-audit JSON reports and keep security jobs non-publishing
- document vulnerability triage expectations for a published PyPI package

## Validation
- verified current action/tool versions: dependency-review-action v5.0.0, codeql-action v4.36.2, pip-audit 2.10.1
- env PATH="$PWD/venv/bin:$PATH" PYTHONNOUSERSITE=1 pre-commit run actionlint --all-files
- clean temporary venv install of .[pandas,arrow] plus pip-audit==2.10.1, then python -m pip_audit --local --strict --format=json --output=pip-audit.json --progress-spinner=off
- env PATH="$PWD/venv/bin:$PATH" PYTHONNOUSERSITE=1 pre-commit run --all-files
- env PATH="$PWD/venv/bin:$PATH" PYTHONNOUSERSITE=1 bash pypi.sh build

Fixes #103