### PR TITLE
Remove legacy setup.py packaging assumptions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,8 +86,24 @@ jobs:
       - name: Compile source and tests
         run: python -m compileall -q src tests test.py snippets.py
 
-      - name: Validate package metadata
-        run: python setup.py check
+      - name: Smoke editable install metadata
+        run: |
+          python - <<'PY'
+          from importlib import metadata
+
+          import histdatacom
+
+          dist = metadata.distribution("histdatacom")
+          scripts = {
+              entry.name: entry.value
+              for entry in metadata.entry_points().select(group="console_scripts")
+          }
+
+          assert dist.metadata["Name"] == "histdatacom"
+          assert metadata.version("histdatacom") == histdatacom.__version__
+          assert scripts["histdatacom"] == "histdatacom.histdata_com:main"
+          PY
+        shell: bash
 
   build:
     name: Build package artifacts
@@ -113,6 +129,55 @@ jobs:
 
       - name: Check package artifacts
         run: python -m twine check dist/*
+
+      - name: Inspect wheel metadata
+        run: |
+          python - <<'PY'
+          from email.parser import Parser
+          from pathlib import Path
+          from zipfile import ZipFile
+
+          wheels = sorted(Path("dist").glob("histdatacom-*.whl"))
+          if len(wheels) != 1:
+              raise SystemExit(f"expected exactly one wheel, found {wheels}")
+
+          with ZipFile(wheels[0]) as wheel:
+              metadata_path = next(
+                  name
+                  for name in wheel.namelist()
+                  if name.endswith(".dist-info/METADATA")
+              )
+              entry_points_path = next(
+                  name
+                  for name in wheel.namelist()
+                  if name.endswith(".dist-info/entry_points.txt")
+              )
+              wheel_metadata = Parser().parsestr(
+                  wheel.read(metadata_path).decode("utf-8")
+              )
+              entry_points = wheel.read(entry_points_path).decode("utf-8")
+
+          assert wheel_metadata["Name"] == "histdatacom"
+          assert wheel_metadata["Requires-Python"] == ">=3.10.0"
+          assert "histdatacom = histdatacom.histdata_com:main" in entry_points
+          PY
+        shell: bash
+
+      - name: Smoke wheel install
+        run: |
+          python -m venv .wheel-smoke
+          . .wheel-smoke/bin/activate
+          python -m pip install --upgrade pip
+          python -m pip install dist/*.whl
+          python - <<'PY'
+          from importlib import metadata
+
+          import histdatacom
+
+          assert metadata.version("histdatacom") == histdatacom.__version__
+          PY
+          histdatacom --version
+        shell: bash
 
       - name: Upload package artifacts
         uses: actions/upload-artifact@v7.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 # Keep source-quality hooks scoped to package and test code. Root helper/example
 # files snippets.py and test.py are intentionally outside that legacy lint
-# baseline; setup.py stays covered by package hooks, while .vulture.py remains a
-# legacy Vulture whitelist and is not linted as ordinary source code.
+# baseline, while .vulture.py remains a legacy Vulture whitelist and is not
+# linted as ordinary source code.
 # Generic config/release hooks still inspect root files such as pyproject.toml,
 # GitHub workflows, pypi.sh, and pre-commit config. Generated architecture SVGs
 # and the example notebook are excluded globally because they are bulky outputs.
@@ -15,12 +15,12 @@ repos:
     - --target-version
     - py310
     id: black
-    files: ^(src|tests)/.*\.py$|^setup\.py$
+    files: ^(src|tests)/.*\.py$
   repo: https://github.com/psf/black
   rev: 26.5.1
 - hooks:
   - id: ruff-check
-    files: ^(src|tests)/.*\.py$|^setup\.py$
+    files: ^(src|tests)/.*\.py$
   repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.15.18
 - hooks:
@@ -53,7 +53,7 @@ repos:
   rev: v2.1.0
 - hooks:
   - id: pyroma
-    files: ^(pyproject\.toml|setup\.py|README\.md|LICENSE)$
+    files: ^(pyproject\.toml|README\.md|LICENSE)$
   repo: https://github.com/regebro/pyroma
   rev: 5.0.1
 - hooks:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -20,6 +20,11 @@ python -m build
 python -m twine check dist/*
 ```
 
+It also inspects the built wheel metadata directly and installs the wheel into
+a fresh virtual environment before any upload command can run. Legacy
+`setup.py` commands are intentionally unsupported; this project is built from
+`pyproject.toml`.
+
 Package metadata is declared in `pyproject.toml`. Local release environments
 must use `setuptools>=77` so the built artifacts include current SPDX license
 metadata.

--- a/pypi.sh
+++ b/pypi.sh
@@ -1,49 +1,130 @@
 #!/usr/bin/env bash
 
-bold=$(tput bold)
-normal=$(tput sgr0)
+set -euo pipefail
+
+bold=$(tput bold 2>/dev/null || true)
+normal=$(tput sgr0 2>/dev/null || true)
+project_root=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+build_dependencies=(
+    build==1.5.0
+    setuptools==80.10.2
+    twine==6.2.0
+    wheel==0.47.0
+)
+
+cd "${project_root}"
+
+install_build_frontend()
+{
+    python -m pip install "${build_dependencies[@]}"
+}
 
 dev()
 {
     echo "${bold}pypi.sh: Setting Up Dev${normal}"
-    pip uninstall -y histdatacom
-    pip install build==1.5.0 setuptools==80.10.2 twine==6.2.0 wheel==0.47.0
-    pip install -e .[dev]
+    python -m pip uninstall -y histdatacom
+    install_build_frontend
+    python -m pip install -e ".[dev]"
     pre-commit install
     echo "${bold}pypi.sh: Dev Ready.${normal}"
+}
+
+inspect_wheel_metadata()
+{
+    python - <<'PY'
+from email.parser import Parser
+from pathlib import Path
+from zipfile import ZipFile
+
+wheels = sorted(Path("dist").glob("histdatacom-*.whl"))
+if len(wheels) != 1:
+    raise SystemExit(f"expected exactly one wheel, found {wheels}")
+
+with ZipFile(wheels[0]) as wheel:
+    metadata_paths = [
+        name for name in wheel.namelist() if name.endswith(".dist-info/METADATA")
+    ]
+    entry_point_paths = [
+        name for name in wheel.namelist() if name.endswith(".dist-info/entry_points.txt")
+    ]
+    if len(metadata_paths) != 1:
+        raise SystemExit(f"expected one METADATA file, found {metadata_paths}")
+    if len(entry_point_paths) != 1:
+        raise SystemExit(f"expected one entry_points.txt file, found {entry_point_paths}")
+
+    wheel_metadata = Parser().parsestr(wheel.read(metadata_paths[0]).decode("utf-8"))
+    entry_points = wheel.read(entry_point_paths[0]).decode("utf-8")
+
+if wheel_metadata["Name"] != "histdatacom":
+    raise SystemExit(f"unexpected wheel name: {wheel_metadata['Name']}")
+if wheel_metadata["Requires-Python"] != ">=3.10.0":
+    raise SystemExit(
+        f"unexpected Python requirement: {wheel_metadata['Requires-Python']}"
+    )
+if "histdatacom = histdatacom.histdata_com:main" not in entry_points:
+    raise SystemExit("histdatacom console script missing from wheel metadata")
+PY
+}
+
+smoke_wheel_install()
+{
+    local smoke_dir
+    smoke_dir=$(mktemp -d)
+
+    (
+        trap 'rm -rf "${smoke_dir}"' EXIT
+
+        python -m venv "${smoke_dir}/venv"
+        # shellcheck source=/dev/null
+        source "${smoke_dir}/venv/bin/activate"
+        python -m pip install --upgrade pip
+        python -m pip install dist/*.whl
+        python - <<'PY'
+from importlib import metadata
+
+import histdatacom
+
+if metadata.version("histdatacom") != histdatacom.__version__:
+    raise SystemExit(
+        "installed package metadata version does not match imported package"
+    )
+PY
+        histdatacom --version
+    )
 }
 
 build()
 {
     rm -rf ./dist
-    pip install build==1.5.0 setuptools==80.10.2 twine==6.2.0 wheel==0.47.0
-    python setup.py check
+    install_build_frontend
     python -m build
     python -m twine check dist/*
+    inspect_wheel_metadata
+    smoke_wheel_install
 }
 
 buildenv()
 {
     echo "${bold}setting up test pip environment${normal}"
-    rm -rf ../myproject
-    mkdir ../myproject
-    cd ../myproject || exit
+    rm -rf "${project_root}/../myproject"
+    mkdir "${project_root}/../myproject"
+    cd "${project_root}/../myproject"
     pwd
     python -m venv venv
     echo "${bold}activating test pip environment${normal}"
     # shellcheck source=/dev/null
     source venv/bin/activate
-    pip install polars
+    python -m pip install polars
     echo "${bold}test pip environment set up complete.${normal}"
 }
 
 destroyenv()
 {
-    cd ../histdata.com-tools || exit
-    rm -rf ../myproject
+    cd "${project_root}"
+    rm -rf "${project_root}/../myproject"
     echo "${bold}leaving test pip environment${normal}"
     # shellcheck source=/dev/null
-    source venv/bin/activate
+    source "${project_root}/venv/bin/activate"
 }
 
 histdatacom_test()
@@ -56,37 +137,39 @@ histdatacom_test()
     histdatacom --version
 }
 
-if [[ $1 == "dev" ]]
-then
-    dev
-    exit 0
-elif [[ $1 == "build" ]]
-then
-    build
-    exit 0
-elif [[ $1 == "pypi" ]]
-then
-    build
-    gpg --detach-sign -a dist/*.tar.gz
-    python -m twine upload -r pypi --config-file .pypirc dist/*.whl dist/*.tar.gz dist/*.asc
-    exit 0
-elif [[ $1 == "testpypi" ]]
-then
-    build
-    gpg --detach-sign -a dist/*.tar.gz
-    python -m twine upload -r testpypi --config-file .pypirc dist/*.whl dist/*.tar.gz dist/*.asc
-elif [[ $1 == "testpypi_install" ]]
-then
-    buildenv
-    echo "${bold}installing histdatacom from testpypi: https://test.pypi.org/simple/${normal}"
-    python3 -m pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ histdatacom
-    histdatacom_test
-    destroyenv
-elif [[ $1 == "pypi_install" ]]
-then
-    buildenv
-    echo "${bold}installing histdatacom from pypi: https://pypi.org/${normal}"
-    pip install histdatacom
-    histdatacom_test
-    destroyenv
-fi
+case "${1:-}" in
+    dev)
+        dev
+        ;;
+    build)
+        build
+        ;;
+    pypi)
+        build
+        gpg --detach-sign -a dist/*.tar.gz
+        python -m twine upload -r pypi --config-file .pypirc dist/*.whl dist/*.tar.gz dist/*.asc
+        ;;
+    testpypi)
+        build
+        gpg --detach-sign -a dist/*.tar.gz
+        python -m twine upload -r testpypi --config-file .pypirc dist/*.whl dist/*.tar.gz dist/*.asc
+        ;;
+    testpypi_install)
+        buildenv
+        echo "${bold}installing histdatacom from testpypi: https://test.pypi.org/simple/${normal}"
+        python -m pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ histdatacom
+        histdatacom_test
+        destroyenv
+        ;;
+    pypi_install)
+        buildenv
+        echo "${bold}installing histdatacom from pypi: https://pypi.org/${normal}"
+        python -m pip install histdatacom
+        histdatacom_test
+        destroyenv
+        ;;
+    *)
+        echo "Usage: $0 {dev|build|pypi|testpypi|testpypi_install|pypi_install}" >&2
+        exit 2
+        ;;
+esac

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,0 @@
-"""Compatibility shim for legacy ``python setup.py`` commands."""
-
-from setuptools import setup
-
-setup()


### PR DESCRIPTION
## Summary

- remove the remaining `setup.py` compatibility shim and all `python setup.py check` invocations
- replace legacy metadata validation with editable-install, wheel metadata, and built-wheel install smoke checks in CI
- update `pypi.sh build` to validate artifacts through `python -m build`, `twine check`, direct wheel inspection, and a fresh-venv install smoke while preserving local upload commands
- document the supported build path in `RELEASE.md`

## Validation

- `env PATH="$PWD/venv/bin:$PATH" PYTHONNOUSERSITE=1 bash pypi.sh build`
- `env PATH="$PWD/venv/bin:$PATH" PYTHONNOUSERSITE=1 pre-commit run --all-files`
- `env PATH="$PWD/venv/bin:$PATH" PYTHONNOUSERSITE=1 python -m pytest -q`

Closes #104