### PR TITLE
[codex] Rationalize runtime dependency extras

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Install test dependencies
         run: |
           python -m pip install --upgrade pip "setuptools>=77" wheel
-          python -m pip install -e ".[pandas,arrow]" pytest pytest-cov
+          python -m pip install -e ".[test]"
 
       - name: Run tests with coverage
         run: python -m pytest --cov=histdatacom --cov-report=term-missing:skip-covered --cov-report=xml --cov-report=html
@@ -122,7 +122,7 @@ jobs:
       - name: Install build dependencies
         run: |
           python -m pip install --upgrade pip "setuptools>=77" wheel
-          python -m pip install build twine
+          python -m pip install -e ".[release]"
 
       - name: Build sdist and wheel
         run: python -m build
@@ -177,6 +177,37 @@ jobs:
           assert metadata.version("histdatacom") == histdatacom.__version__
           PY
           histdatacom --version
+        shell: bash
+
+      - name: Smoke wheel extras install
+        run: |
+          python -m venv .wheel-extras-smoke
+          . .wheel-extras-smoke/bin/activate
+          python -m pip install --upgrade pip
+          wheel="$(ls dist/*.whl)"
+          python -m pip install "${wheel}[all]"
+          python - <<'PY'
+          from importlib import metadata
+          import importlib.util
+
+          for distribution_name in (
+              "influxdb-client",
+              "ipywidgets",
+              "jupyter",
+              "pandas",
+              "pyarrow",
+          ):
+              metadata.version(distribution_name)
+
+          for module_name in (
+              "influxdb_client",
+              "ipywidgets",
+              "pandas",
+              "pyarrow",
+          ):
+              if importlib.util.find_spec(module_name) is None:
+                  raise SystemExit(f"missing expected optional module {module_name}")
+          PY
         shell: bash
 
       - name: Upload package artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Install build dependencies
         run: |
           python -m pip install --upgrade pip "setuptools>=77" wheel
-          python -m pip install build twine
+          python -m pip install -e ".[release]"
 
       - name: Build sdist and wheel
         run: python -m build

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Install audit environment
         run: |
           python -m pip install --upgrade pip "setuptools>=77" wheel
-          python -m pip install -e ".[pandas,arrow]"
+          python -m pip install -e ".[all]"
           python -m pip install "pip-audit==2.10.1"
 
       - name: Run pip-audit

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # histdata.com-tools
 
-A Multi-threaded/Multi-Process command-line utility and python ETL package that downloads currency exchange rates from Histdata.com. Imports to InfluxDB. Can be used in Jupyter Notebooks. Works on MacOS, Linux & Windows Systems.
+A Multi-threaded/Multi-Process command-line utility and python ETL package that downloads currency exchange rates from Histdata.com. Optional InfluxDB and Jupyter integrations are available through extras. Works on MacOS, Linux & Windows Systems.
 **Requires Python3.10+**
 
 **NEW:** Expanded API support!!!
@@ -262,7 +262,11 @@ histdatacom -c medium -p udxusd -f metatrader -s 2015-04 -e 2016-04
 
 ### Import to InfluxDB
 
-To import data to an influxdb instance, use the `-I --import_to_influxdb` flag along with an `influxdb.yaml` file in the current working directory (where ever you are running the command from).
+To import data to an influxdb instance, install the Influx extra and use the `-I --import_to_influxdb` flag along with an `influxdb.yaml` file in the current working directory (where ever you are running the command from).
+
+```sh
+pip install "histdatacom[influx]"
+```
 
 - ascii is the only format accepted for influxdb import.
 - all histdata.com datetime data is in EST (Eastern Standard Time) with no adjustments for daylight savings.
@@ -369,6 +373,9 @@ As opposed to the `CLI` interface, one may wish to load data from histdata.com a
 - *to use `pandas` or `arrow` return formats, install the optional extras*
   - `pip install "histdatacom[pandas]"`
   - `pip install "histdatacom[arrow]"`
+- *to use InfluxDB imports or notebook tooling, install the corresponding extras*
+  - `pip install "histdatacom[influx]"`
+  - `pip install "histdatacom[jupyter]"`
 
 - ***All datetime is returned as milliseconds since January 1, 1970 (midnight UTC/GMT)***
 
@@ -603,6 +610,14 @@ pip install "histdatacom[pandas]"
 pip install "histdatacom[arrow]"
 ```
 
+InfluxDB import and notebook support are optional:
+
+```sh
+pip install "histdatacom[influx]"
+pip install "histdatacom[jupyter]"
+pip install "histdatacom[all]"
+```
+
 to install latest development version
 
 ```sh
@@ -621,11 +636,22 @@ PYTHONNOUSERSITE=1 python -m pip install -e ".[dev]"
 PYTHONNOUSERSITE=1 pre-commit install --install-hooks
 ```
 
-The `dev` extra pins the direct developer tools used by pre-commit. The active
-lint baseline is Black, Ruff, mypy, generic file checks, Pyroma, ShellCheck,
-Commitizen, and the local CLI/coverage smoke hooks. The previous flake8 plugin
-stack was intentionally replaced with Ruff so local installs and hook behavior
-do not drift independently.
+The dependency surfaces are split by purpose:
+
+- `.[test]` installs pytest, coverage, pandas, pyarrow, and InfluxDB support
+  used by the test suite.
+- `.[lint]` installs pre-commit and direct lint/type/doc hygiene tools.
+- `.[release]` installs build and publish tooling.
+- `.[dev]` is the aggregate local contributor environment with test, lint,
+  release, and optional integration dependencies.
+
+The `dev`, `lint`, `test`, and `release` extras pin direct developer tools
+where reproducibility matters. Runtime dependencies keep compatibility lower
+bounds rather than lock-file pins because `histdatacom` is a published PyPI
+library. The active lint baseline is Black, Ruff, mypy, generic file checks,
+Pyroma, ShellCheck, Commitizen, and the local CLI/coverage smoke hooks. The
+previous flake8 plugin stack was intentionally replaced with Ruff so local
+installs and hook behavior do not drift independently.
 
 ### Coverage Policy
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -158,10 +158,25 @@ The security workflow runs on pull requests, pushes to `main`, manual dispatch,
 and a weekly schedule. It has no publishing permissions. Dependency Review is
 enabled for pull requests on this public repository and fails when dependency
 changes introduce moderate, high, or critical vulnerabilities in runtime or
-development scopes. `pip-audit` installs the package with the pandas and arrow
-optional dependencies, audits the resulting Python environment, and uploads a
+development scopes. `pip-audit` installs the package with all optional runtime
+and integration extras, audits the resulting Python environment, and uploads a
 JSON report. CodeQL analyzes the Python source with no build step; it only has
 `security-events: write` so GitHub can receive code-scanning results.
+
+The package metadata intentionally separates dependency surfaces:
+
+- Runtime dependencies support ordinary `pip install histdatacom` users and use
+  lower bounds instead of lock-file pins so downstream applications can resolve
+  compatible environments.
+- Optional integrations live behind extras such as `histdatacom[pandas]`,
+  `histdatacom[arrow]`, `histdatacom[influx]`, and `histdatacom[jupyter]`.
+- `histdatacom[test]`, `histdatacom[lint]`, and `histdatacom[release]` split
+  contributor tooling by purpose. `histdatacom[dev]` aggregates those direct
+  tool pins plus optional integration dependencies for local development.
+- This project does not keep a committed lock file for runtime dependencies
+  because it is a published library package. For local reproducibility, create a
+  fresh virtual environment, install `.[dev]`, and use the pinned pre-commit
+  hook revisions and direct developer-tool pins.
 
 For a published PyPI package, triage vulnerability findings by affected install
 surface:
@@ -170,8 +185,9 @@ surface:
   should be patched with a minimum-version floor or compatible dependency range
   before publishing a patch release.
 - Optional dependency findings affect users who install extras such as
-  `histdatacom[pandas]` or `histdatacom[arrow]`; patch those ranges and mention
-  the affected extra in release notes.
+  `histdatacom[pandas]`, `histdatacom[arrow]`, `histdatacom[influx]`, or
+  `histdatacom[jupyter]`; patch those ranges and mention the affected extra in
+  release notes.
 - Development and build findings block contributor or release hygiene but do
   not automatically require a PyPI release unless the vulnerable package is
   included in built distributions or runtime metadata.

--- a/pypi.sh
+++ b/pypi.sh
@@ -5,25 +5,18 @@ set -euo pipefail
 bold=$(tput bold 2>/dev/null || true)
 normal=$(tput sgr0 2>/dev/null || true)
 project_root=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-build_dependencies=(
-    build==1.5.0
-    setuptools==80.10.2
-    twine==6.2.0
-    wheel==0.47.0
-)
 
 cd "${project_root}"
 
-install_build_frontend()
+install_release_frontend()
 {
-    python -m pip install "${build_dependencies[@]}"
+    python -m pip install -e ".[release]"
 }
 
 dev()
 {
     echo "${bold}pypi.sh: Setting Up Dev${normal}"
     python -m pip uninstall -y histdatacom
-    install_build_frontend
     python -m pip install -e ".[dev]"
     pre-commit install
     echo "${bold}pypi.sh: Dev Ready.${normal}"
@@ -103,7 +96,7 @@ sign_dist_artifacts()
 build()
 {
     rm -rf ./dist
-    install_build_frontend
+    install_release_frontend
     python -m build
     python -m twine check dist/*
     inspect_wheel_metadata

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "histdatacom"
 dynamic = ["version"]
-description = "A Multi-threaded/Multi-Process command-line utility and python package that downloads currency exchange rates from Histdata.com. Imports to InfluxDB. Can be used in Jupyter Notebooks."
+description = "A Multi-threaded/Multi-Process command-line utility and python package that downloads currency exchange rates from Histdata.com. Optional InfluxDB and Jupyter integrations are available through extras."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10.0"
 license = "MIT"
@@ -41,54 +41,88 @@ classifiers = [
     "Topic :: Terminals",
 ]
 dependencies = [
-    "influxdb_client",
-    "rich",
-    "requests",
-    "beautifulsoup4",
-    "pyyaml",
-    "rx",
-    "argparse",
-    "pytz",
-    "certifi",
-    "polars",
+    "beautifulsoup4>=4.12",
+    "certifi>=2024.2.2",
+    "polars>=1.0",
+    "pytz>=2024.1",
+    "PyYAML>=6.0",
+    "requests>=2.28",
+    "rich>=12.0",
+    "Rx>=3.2",
 ]
 
 [project.optional-dependencies]
 arrow = [
-    "pyarrow",
+    "pyarrow>=16.0",
+]
+influx = [
+    "influxdb-client>=1.36",
 ]
 pandas = [
-    "pandas",
+    "pandas>=2.0",
 ]
 jupyter = [
     "jupyter",
     "ipywidgets",
 ]
-dev = [
-    "pyarrow",
-    "pandas",
-    "polars",
-    "jupyter",
+all = [
+    "influxdb-client>=1.36",
     "ipywidgets",
-    "build==1.5.0",
-    "twine==6.2.0",
-    "wheel==0.47.0",
-    "setuptools==80.10.2",
-    "pytest==9.1.1",
+    "jupyter",
+    "pandas>=2.0",
+    "pyarrow>=16.0",
+]
+test = [
     "coverage==7.14.2",
+    "influxdb-client>=1.36",
+    "pandas>=2.0",
+    "pyarrow>=16.0",
+    "pytest==9.1.1",
     "pytest-cov==7.1.0",
-    "pre-commit==4.6.0",
+]
+lint = [
     "black==26.5.1",
-    "ruff==0.15.18",
-    "mypy==2.1.0",
-    "pyroma==5.0.1",
     "commitizen==4.16.3",
-    "shellcheck-py==0.11.0.1",
+    "mypy==2.1.0",
     "pandas-stubs==3.0.3.260530",
+    "pre-commit==4.6.0",
+    "pyroma==5.0.1",
+    "ruff==0.15.18",
+    "shellcheck-py==0.11.0.1",
     "types-beautifulsoup4==4.12.0.20250516",
     "types-PyYAML==6.0.12.20260518",
+]
+release = [
+    "build==1.5.0",
     "keyring==25.7.0",
-    "sh==2.3.0",
+    "setuptools==80.10.2",
+    "twine==6.2.0",
+    "wheel==0.47.0",
+]
+dev = [
+    "build==1.5.0",
+    "black==26.5.1",
+    "commitizen==4.16.3",
+    "coverage==7.14.2",
+    "influxdb-client>=1.36",
+    "ipywidgets",
+    "jupyter",
+    "keyring==25.7.0",
+    "mypy==2.1.0",
+    "pandas>=2.0",
+    "pandas-stubs==3.0.3.260530",
+    "pre-commit==4.6.0",
+    "pyroma==5.0.1",
+    "pyarrow>=16.0",
+    "pytest==9.1.1",
+    "pytest-cov==7.1.0",
+    "ruff==0.15.18",
+    "setuptools==80.10.2",
+    "shellcheck-py==0.11.0.1",
+    "twine==6.2.0",
+    "types-beautifulsoup4==4.12.0.20250516",
+    "types-PyYAML==6.0.12.20260518",
+    "wheel==0.47.0",
 ]
 
 [project.urls]

--- a/src/histdatacom/fx_enums.py
+++ b/src/histdatacom/fx_enums.py
@@ -3,8 +3,6 @@
 # pylint: disable=invalid-name
 from enum import Enum
 
-from influxdb_client import WritePrecision
-
 # Majors 7
 # eurusd usdjpy gbpusd usdcad usdchf audusd nzdusd
 
@@ -262,7 +260,7 @@ class TimeFormat(Enum):  # noqa:H601
 
 
 class TimePrecision(Enum):  # noqa:H601
-    """Enumerate list of public TimePrecisions for influxdb writer.
+    """Enumerate list of public InfluxDB write precisions.
 
     Args:
         Enum (Enum): Parent Class
@@ -273,14 +271,14 @@ class TimePrecision(Enum):  # noqa:H601
                 TimePrecision.list_values()
     """
 
-    MT_M1 = WritePrecision.S
-    ASCII_M1 = WritePrecision.S
-    ASCII_T = WritePrecision.MS
-    NT_M1 = WritePrecision.S
-    NT_T_LAST = WritePrecision.S
-    NT_T_BID = WritePrecision.S
-    NT_T_ASK = WritePrecision.S
-    MS_M1 = WritePrecision.S
+    MT_M1 = "s"
+    ASCII_M1 = "s"
+    ASCII_T = "ms"
+    NT_M1 = "s"
+    NT_T_LAST = "s"
+    NT_T_BID = "s"
+    NT_T_ASK = "s"
+    MS_M1 = "s"
 
     @classmethod
     def list_keys(cls) -> set:

--- a/src/histdatacom/histdata_com.py
+++ b/src/histdatacom/histdata_com.py
@@ -77,6 +77,7 @@ class _HistDataCom:  # noqa:R701
         )
 
         if config.ARGS["import_to_influxdb"]:
+            check_installed_module("influxdb_client")
             influx_yaml = load_influx_yaml()
             config.ARGS["INFLUX_ORG"] = influx_yaml["influxdb"]["org"]
             config.ARGS["INFLUX_BUCKET"] = influx_yaml["influxdb"]["bucket"]

--- a/src/histdatacom/utils.py
+++ b/src/histdatacom/utils.py
@@ -3,14 +3,14 @@
 from __future__ import annotations
 
 import hashlib
+import importlib
 import json
 import os
 from pathlib import Path
 import re
+import sys
 from datetime import datetime
 from typing import Any, Optional
-import sys
-import importlib
 
 import pytz
 import yaml
@@ -20,6 +20,20 @@ API_RETURN_TYPE_MODULES = {
     "arrow": "pyarrow",
     "pandas": "pandas",
     "polars": "polars",
+}
+
+OPTIONAL_MODULE_EXTRAS = {
+    "influxdb_client": "influx",
+    "pandas": "pandas",
+    "polars": "polars",
+    "pyarrow": "arrow",
+}
+
+OPTIONAL_MODULE_FEATURES = {
+    "influxdb_client": "InfluxDB import",
+    "pandas": "pandas return format",
+    "polars": "polars return format",
+    "pyarrow": "arrow return format",
 }
 
 SUPPORTED_API_RETURN_TYPES = frozenset(API_RETURN_TYPE_MODULES)
@@ -224,6 +238,7 @@ def check_installed_module(  # noqa:CCR001,BLK100
     Returns:
         bool: True module is installed and available
     """
+    requested_module_name = module_name
     if module_name in API_RETURN_TYPE_MODULES:
         module_name = API_RETURN_TYPE_MODULES[module_name]
 
@@ -238,13 +253,17 @@ def check_installed_module(  # noqa:CCR001,BLK100
             spec.loader.exec_module(module)  # type: ignore
         return True
     else:
-        if module_name == "pyarrow":
-            module_name = "arrow"
+        extra_name = OPTIONAL_MODULE_EXTRAS.get(
+            module_name, requested_module_name
+        )
+        feature_name = OPTIONAL_MODULE_FEATURES.get(
+            module_name, f"{requested_module_name} format"
+        )
 
         err_text = (
-            f"{module_name} format not installed. "
+            f"{feature_name} not installed. "
             "please run:\n\n  "
-            f"pip install histdatacom[{module_name}]"
+            f"pip install histdatacom[{extra_name}]"
             "\n\n to install."
         )
 

--- a/tests/unit/test_fx_enums.py
+++ b/tests/unit/test_fx_enums.py
@@ -1,6 +1,15 @@
 """Pytest unit tests for histdatacom.fx_enums.py."""
 
+from histdatacom.fx_enums import TimePrecision
+
 
 def test_fx_enums() -> None:
     """Test pytest path resolution."""
     assert True  # noqa:S101 # sourcery skip # act
+
+
+def test_time_precision_values_do_not_require_influxdb_client() -> None:
+    """Influx precision metadata should stay importable without Influx."""
+    assert TimePrecision.ASCII_M1.value == "s"
+    assert TimePrecision.ASCII_T.value == "ms"
+    assert TimePrecision.list_values() == {"s", "ms"}

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,7 +1,9 @@
 """Pytest unit tests for histdatacom.utils.py."""
 
+import importlib.util
 import os
 from pathlib import Path
+import sys
 
 import pytest
 
@@ -62,6 +64,29 @@ def test_api_return_type_contract_is_explicit() -> None:
 def test_check_installed_module_accepts_polars_return_type() -> None:
     """Polars is now the default dataframe dependency."""
     assert check_installed_module("polars")
+
+
+def test_check_installed_module_reports_influx_extra(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Influx should report its optional extra instead of a generic format."""
+    real_find_spec = importlib.util.find_spec
+
+    def fake_find_spec(
+        module_name: str,
+    ) -> importlib.machinery.ModuleSpec | None:
+        if module_name == "influxdb_client":
+            return None
+        return real_find_spec(module_name)
+
+    monkeypatch.setattr(importlib.util, "find_spec", fake_find_spec)
+    monkeypatch.delitem(sys.modules, "influxdb_client", raising=False)
+
+    with pytest.raises(SystemExit) as err:
+        check_installed_module("influxdb_client")
+
+    assert "InfluxDB import not installed" in str(err.value)
+    assert "pip install histdatacom[influx]" in str(err.value)
 
 
 def test_set_working_data_dir_expands_relative_paths(


### PR DESCRIPTION
## Summary
- remove stdlib `argparse` and mandatory InfluxDB from runtime dependencies
- add explicit `influx`, `test`, `lint`, `release`, `all`, and aggregate `dev` extras
- keep default imports working without Influx and show `histdatacom[influx]` guidance only on Influx workflows
- update CI, release, security workflows, README, RELEASE notes, and pypi.sh to use the new dependency surfaces

Closes #106

## Validation
- `python -m pytest`
- `pre-commit run --all-files`
- `./pypi.sh build`
- fresh `pip install .` default install smoke
- fresh `pip install -e .` default install smoke
- fresh `pip install ".[all]"` optional extras smoke
