### PR TITLE
Add Docker-backed live InfluxDB smoke validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Works on MacOS, Linux & Windows Systems.
   - [Multiple Datasets](#multiple-datasets)
   - [CPU Utilization](#cpu-utilization)
   - [Import to InfluxDB](#import-to-influxdb)
+    - [Docker-backed InfluxDB Smoke](#docker-backed-influxdb-smoke)
     - [influxdb.yaml](#influxdbyaml)
   - [Temporal Sidecar Compatibility](#temporal-sidecar-compatibility)
     - [Runtime Model and Install Surface](#runtime-model-and-install-surface)
@@ -291,6 +292,21 @@ pip install "histdatacom[influx]"
 ```txt
 histdatacom -I -p eurusd -f ascii -t tick-data-quotes -s start -e now
 ```
+
+#### Docker-backed InfluxDB Smoke
+
+When Docker is available, contributors can run a disposable InfluxDB v2 smoke
+without a user-managed `influxdb.yaml`:
+
+```sh
+python scripts/smoke_influx_docker.py
+```
+
+The smoke starts `influxdb:2.7-alpine`, writes representative HistData M1 and
+tick line-protocol batches through the real `InfluxBatchWriter`, queries the
+bucket, reports the field count, and removes the container. It is intentionally
+not part of default pytest because it depends on Docker and a pullable InfluxDB
+image.
 
 #### influxdb.yaml
 

--- a/docs/temporal-sidecar-operations.md
+++ b/docs/temporal-sidecar-operations.md
@@ -697,7 +697,10 @@ InfluxDB unavailable:
   `-I/--import_to_influxdb`. The sidecar does not provide an InfluxDB service.
   Local contract tests replace only the final writer and do not prove live
   credentials, bucket permissions, network latency, or server-side write
-  rejection behavior.
+  rejection behavior. When Docker is available, run
+  `python scripts/smoke_influx_docker.py` to start a disposable InfluxDB v2
+  container, write representative HistData line protocol through the real
+  `InfluxBatchWriter`, query the bucket, and tear the container down.
 
 Data-quality checks:
 
@@ -720,7 +723,8 @@ Unit tests should keep most coverage independent from live Temporal and Influx:
 - performance profile and benchmark fixture tests
 
 Live smoke tests belong behind explicit operator setup because they require a
-Temporal executable, and live import coverage requires a real Influx target.
+Temporal executable, and live import coverage requires a real Influx target or
+the Docker-backed `scripts/smoke_influx_docker.py` helper.
 Package release smoke should validate metadata, console entry points, packaged
 sidecar resources, and offline `status`/`doctor` behavior for every wheel. For
 bundled platform wheels, release smoke should also require

--- a/docs/temporal-sidecar-performance.md
+++ b/docs/temporal-sidecar-performance.md
@@ -178,7 +178,8 @@ with a local writer. This proves:
 This does not prove live Influx authentication, bucket permissions, network
 latency, server-side write rejection behavior, or production retention policy.
 Those remain operator-gated live checks requiring `histdatacom[influx]`, a real
-`influxdb.yaml`, and a disposable target bucket.
+`influxdb.yaml`, a disposable target bucket, or the Docker-backed
+`python scripts/smoke_influx_docker.py` helper.
 
 ## Tuning Guidance
 
@@ -244,8 +245,10 @@ The accepted issue #181 envelope is:
 
 Live run date: 2026-06-21. Temporal executable:
 `/opt/local/bin/temporal`. InfluxDB was intentionally unavailable for the live
-matrix. Influx behavior is covered by the issue #187 contract-backed workflow
-test described above.
+matrix at that time. Influx behavior is covered by the issue #187
+contract-backed workflow test described above, and Docker-backed live
+writer/query validation is available through
+`python scripts/smoke_influx_docker.py`.
 
 | Scenario | Retired baseline elapsed | Sidecar elapsed | Ratio | Sidecar process CPU | Artifacts | Failures/retries |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: |

--- a/scripts/smoke_influx_docker.py
+++ b/scripts/smoke_influx_docker.py
@@ -1,0 +1,432 @@
+"""Run a Docker-backed live InfluxDB smoke for histdatacom imports."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import secrets
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+DEFAULT_INFLUX_IMAGE = "influxdb:2.7-alpine"
+DEFAULT_ORG = "histdatacom"
+DEFAULT_BUCKET = "histdatacom-smoke"
+DEFAULT_USERNAME = "histdatacom"
+DEFAULT_PASSWORD = "histdatacom-password"
+DEFAULT_TOKEN = "histdatacom-smoke-token"
+DEFAULT_STARTUP_TIMEOUT = 60.0
+INFLUX_PORT = "8086/tcp"
+SMOKE_MEASUREMENT = "eurusd"
+SMOKE_LINES = (
+    "eurusd,source=histdata.com,format=ascii,timeframe=M1 "
+    "openbid=1.30657,highbid=1.30657,lowbid=1.30647,closebid=1.30656 "
+    "1328072460000",
+    "eurusd,source=histdata.com,format=ascii,timeframe=T "
+    "bidquote=1.30658,askquote=1.30675 1328072403973",
+)
+EXPECTED_FIELD_COUNT = 6
+
+RunCommand = Callable[..., subprocess.CompletedProcess[str]]
+HealthWaiter = Callable[[str, float], Mapping[str, Any]]
+
+
+class DockerInfluxSmokeError(RuntimeError):
+    """Raised when the Docker-backed Influx smoke fails."""
+
+    def __init__(self, message: str, diagnostics: Mapping[str, Any]) -> None:
+        super().__init__(message)
+        self.diagnostics = dict(diagnostics)
+
+
+@dataclass(frozen=True, slots=True)
+class InfluxContainer:
+    """Running InfluxDB container details."""
+
+    container_id: str
+    name: str
+    url: str
+    host: str
+    port: int
+
+    def to_dict(self) -> dict[str, str | int]:
+        """Return JSON-compatible container details."""
+        return {
+            "container_id": self.container_id,
+            "name": self.name,
+            "url": self.url,
+            "host": self.host,
+            "port": self.port,
+        }
+
+
+def _run(
+    command: Sequence[str],
+    *,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    """Run a command with captured output and optional failure checking."""
+    completed = subprocess.run(
+        list(command),
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+    if check and completed.returncode != 0:
+        raise DockerInfluxSmokeError(
+            f"command failed with exit {completed.returncode}: "
+            f"{' '.join(command)}",
+            {
+                "command": list(command),
+                "returncode": completed.returncode,
+                "stdout": completed.stdout,
+                "stderr": completed.stderr,
+            },
+        )
+    return completed
+
+
+def _default_container_name() -> str:
+    return f"histdatacom-influx-smoke-{os.getpid()}-{secrets.token_hex(4)}"
+
+
+def _parse_docker_port(port_output: str) -> tuple[str, int]:
+    """Parse `docker port` output into a host and integer port."""
+    for line in port_output.splitlines():
+        endpoint = line.strip()
+        if not endpoint:
+            continue
+        host, separator, raw_port = endpoint.rpartition(":")
+        if separator and raw_port.isdigit():
+            return host.strip("[]") or "127.0.0.1", int(raw_port)
+    raise DockerInfluxSmokeError(
+        "docker did not report a published InfluxDB port",
+        {"docker_port_output": port_output},
+    )
+
+
+def start_influx_container(
+    *,
+    image: str = DEFAULT_INFLUX_IMAGE,
+    container_name: str | None = None,
+    org: str = DEFAULT_ORG,
+    bucket: str = DEFAULT_BUCKET,
+    username: str = DEFAULT_USERNAME,
+    password: str = DEFAULT_PASSWORD,
+    token: str = DEFAULT_TOKEN,
+    startup_timeout: float = DEFAULT_STARTUP_TIMEOUT,
+    run_command: RunCommand = _run,
+    wait_for_health: HealthWaiter | None = None,
+) -> InfluxContainer:
+    """Start a disposable InfluxDB v2 container and wait for readiness."""
+    name = container_name or _default_container_name()
+    completed = run_command(
+        [
+            "docker",
+            "run",
+            "--detach",
+            "--rm",
+            "--name",
+            name,
+            "--publish",
+            "127.0.0.1::8086",
+            "--env",
+            "DOCKER_INFLUXDB_INIT_MODE=setup",
+            "--env",
+            f"DOCKER_INFLUXDB_INIT_USERNAME={username}",
+            "--env",
+            f"DOCKER_INFLUXDB_INIT_PASSWORD={password}",
+            "--env",
+            f"DOCKER_INFLUXDB_INIT_ORG={org}",
+            "--env",
+            f"DOCKER_INFLUXDB_INIT_BUCKET={bucket}",
+            "--env",
+            f"DOCKER_INFLUXDB_INIT_ADMIN_TOKEN={token}",
+            image,
+        ]
+    )
+    container_id = completed.stdout.strip()
+    port_output = run_command(["docker", "port", name, INFLUX_PORT]).stdout
+    host, port = _parse_docker_port(port_output)
+    url = f"http://{host}:{port}"
+    health = wait_for_health or wait_for_influx_health
+    health(url, startup_timeout)
+    return InfluxContainer(
+        container_id=container_id,
+        name=name,
+        url=url,
+        host=host,
+        port=port,
+    )
+
+
+def wait_for_influx_health(
+    url: str,
+    timeout: float = DEFAULT_STARTUP_TIMEOUT,
+) -> dict[str, Any]:
+    """Poll the InfluxDB health endpoint until it reports readiness."""
+    deadline = time.monotonic() + timeout
+    health_url = f"{url.rstrip('/')}/health"
+    last_error = ""
+    while time.monotonic() < deadline:
+        try:
+            with urllib.request.urlopen(health_url, timeout=2.0) as response:
+                body = response.read().decode("utf-8", errors="replace")
+                payload = json.loads(body) if body else {}
+                status = str(payload.get("status", "")).lower()
+                if response.status < 500 and status == "pass":
+                    return payload
+                last_error = body
+        except (
+            OSError,
+            TimeoutError,
+            urllib.error.HTTPError,
+            urllib.error.URLError,
+            json.JSONDecodeError,
+        ) as err:
+            last_error = repr(err)
+        time.sleep(0.5)
+    raise DockerInfluxSmokeError(
+        "InfluxDB container did not become healthy",
+        {"url": health_url, "last_error": last_error},
+    )
+
+
+def stop_influx_container(
+    container: InfluxContainer,
+    *,
+    run_command: RunCommand = _run,
+) -> subprocess.CompletedProcess[str]:
+    """Force-remove the disposable InfluxDB container."""
+    return run_command(["docker", "rm", "--force", container.name])
+
+
+def docker_logs(
+    container: InfluxContainer,
+    *,
+    run_command: RunCommand = _run,
+) -> str:
+    """Return current Docker logs for diagnostics."""
+    completed = run_command(
+        ["docker", "logs", container.name],
+        check=False,
+    )
+    return completed.stdout + completed.stderr
+
+
+def write_and_verify_influx(
+    *,
+    url: str,
+    org: str = DEFAULT_ORG,
+    bucket: str = DEFAULT_BUCKET,
+    token: str = DEFAULT_TOKEN,
+    lines: Sequence[str] = SMOKE_LINES,
+    expected_field_count: int = EXPECTED_FIELD_COUNT,
+    writer_factory: Callable[[Mapping[str, Any]], Any] | None = None,
+    client_factory: Callable[..., Any] | None = None,
+) -> dict[str, Any]:
+    """Write representative line-protocol batches and verify via Flux query."""
+    writer_factory = writer_factory or _influx_batch_writer_factory()
+    args = {
+        "INFLUX_ORG": org,
+        "INFLUX_BUCKET": bucket,
+        "INFLUX_URL": url,
+        "INFLUX_TOKEN": token,
+    }
+    with writer_factory(args) as writer:
+        for line in lines:
+            writer.write_lines([line])
+
+    field_count = query_influx_field_count(
+        url=url,
+        org=org,
+        bucket=bucket,
+        token=token,
+        client_factory=client_factory,
+    )
+    if field_count < expected_field_count:
+        raise DockerInfluxSmokeError(
+            "InfluxDB smoke query returned fewer fields than expected",
+            {
+                "expected_field_count": expected_field_count,
+                "actual_field_count": field_count,
+                "url": url,
+                "bucket": bucket,
+            },
+        )
+    return {
+        "written_lines": len(lines),
+        "expected_field_count": expected_field_count,
+        "actual_field_count": field_count,
+    }
+
+
+def query_influx_field_count(
+    *,
+    url: str,
+    org: str = DEFAULT_ORG,
+    bucket: str = DEFAULT_BUCKET,
+    token: str = DEFAULT_TOKEN,
+    measurement: str = SMOKE_MEASUREMENT,
+    client_factory: Callable[..., Any] | None = None,
+) -> int:
+    """Return the number of field values written for the smoke measurement."""
+    client_factory = client_factory or _influx_client_factory()
+    query = (
+        f'from(bucket: "{bucket}") '
+        "|> range(start: 2012-02-01T00:00:00Z, "
+        "stop: 2012-02-02T00:00:00Z) "
+        f'|> filter(fn: (r) => r._measurement == "{measurement}") '
+        '|> count(column: "_value")'
+    )
+    with client_factory(url=url, token=token, org=org) as client:
+        tables = client.query_api().query(query, org=org)
+    return _sum_query_record_values(tables)
+
+
+def _sum_query_record_values(tables: Any) -> int:
+    total = 0
+    for table in tables:
+        for record in getattr(table, "records", ()):
+            value = record.get_value()
+            total += int(value)
+    return total
+
+
+def _influx_batch_writer_factory() -> Callable[[Mapping[str, Any]], Any]:
+    from histdatacom.influx import InfluxBatchWriter
+
+    return InfluxBatchWriter
+
+
+def _influx_client_factory() -> Callable[..., Any]:
+    from influxdb_client import InfluxDBClient
+
+    return InfluxDBClient
+
+
+def run_docker_influx_smoke(
+    *,
+    image: str = DEFAULT_INFLUX_IMAGE,
+    container_name: str | None = None,
+    org: str = DEFAULT_ORG,
+    bucket: str = DEFAULT_BUCKET,
+    username: str = DEFAULT_USERNAME,
+    password: str = DEFAULT_PASSWORD,
+    token: str = DEFAULT_TOKEN,
+    startup_timeout: float = DEFAULT_STARTUP_TIMEOUT,
+    keep_container: bool = False,
+    run_command: RunCommand = _run,
+    wait_for_health: HealthWaiter | None = None,
+    writer_factory: Callable[[Mapping[str, Any]], Any] | None = None,
+    client_factory: Callable[..., Any] | None = None,
+) -> dict[str, Any]:
+    """Run the full Docker-backed InfluxDB smoke and return a report."""
+    container: InfluxContainer | None = None
+    diagnostics: dict[str, Any] = {}
+    try:
+        container = start_influx_container(
+            image=image,
+            container_name=container_name,
+            org=org,
+            bucket=bucket,
+            username=username,
+            password=password,
+            token=token,
+            startup_timeout=startup_timeout,
+            run_command=run_command,
+            wait_for_health=wait_for_health,
+        )
+        write_report = write_and_verify_influx(
+            url=container.url,
+            org=org,
+            bucket=bucket,
+            token=token,
+            writer_factory=writer_factory,
+            client_factory=client_factory,
+        )
+        return {
+            "status": "passed",
+            "image": image,
+            "container": container.to_dict(),
+            "influx": {
+                "org": org,
+                "bucket": bucket,
+                "url": container.url,
+            },
+            "write": write_report,
+        }
+    except Exception as err:
+        diagnostics["error"] = repr(err)
+        if container is not None:
+            diagnostics["container"] = container.to_dict()
+            diagnostics["logs"] = docker_logs(
+                container,
+                run_command=run_command,
+            )
+        if isinstance(err, DockerInfluxSmokeError):
+            diagnostics.update(err.diagnostics)
+        raise DockerInfluxSmokeError(
+            f"Docker InfluxDB smoke failed: {err}",
+            diagnostics,
+        ) from err
+    finally:
+        if container is not None and not keep_container:
+            stop_influx_container(container, run_command=run_command)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the command-line parser."""
+    parser = argparse.ArgumentParser(
+        description="Run a Docker-backed live InfluxDB smoke."
+    )
+    parser.add_argument("--image", default=DEFAULT_INFLUX_IMAGE)
+    parser.add_argument("--container-name", default=None)
+    parser.add_argument("--org", default=DEFAULT_ORG)
+    parser.add_argument("--bucket", default=DEFAULT_BUCKET)
+    parser.add_argument("--username", default=DEFAULT_USERNAME)
+    parser.add_argument("--password", default=DEFAULT_PASSWORD)
+    parser.add_argument("--token", default=DEFAULT_TOKEN)
+    parser.add_argument(
+        "--startup-timeout",
+        type=float,
+        default=DEFAULT_STARTUP_TIMEOUT,
+    )
+    parser.add_argument(
+        "--keep-container",
+        action="store_true",
+        help="leave the InfluxDB container running after the smoke",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the Docker-backed live InfluxDB smoke."""
+    args = build_parser().parse_args(argv)
+    try:
+        report = run_docker_influx_smoke(
+            image=args.image,
+            container_name=args.container_name,
+            org=args.org,
+            bucket=args.bucket,
+            username=args.username,
+            password=args.password,
+            token=args.token,
+            startup_timeout=args.startup_timeout,
+            keep_container=args.keep_container,
+        )
+    except DockerInfluxSmokeError as err:
+        print(json.dumps(err.diagnostics, indent=2, sort_keys=True), file=sys.stderr)
+        return 1
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_smoke_influx_docker.py
+++ b/tests/unit/test_smoke_influx_docker.py
@@ -1,0 +1,267 @@
+"""Tests for the Docker-backed live InfluxDB smoke helper."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _module():
+    script_path = (
+        Path(__file__).resolve().parents[2]
+        / "scripts"
+        / "smoke_influx_docker.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "smoke_influx_docker",
+        script_path,
+    )
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _completed(module: Any, stdout: str = "", stderr: str = "") -> Any:
+    return module.subprocess.CompletedProcess(
+        args=["docker"],
+        returncode=0,
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+
+def test_parse_docker_port_accepts_bound_ipv4_port() -> None:
+    """Docker port output should become a localhost endpoint."""
+    module = _module()
+
+    assert module._parse_docker_port("127.0.0.1:49153\n") == (
+        "127.0.0.1",
+        49153,
+    )
+
+
+def test_start_influx_container_sets_up_disposable_service() -> None:
+    """The Docker command should create a one-shot initialized InfluxDB v2."""
+    module = _module()
+    calls: list[tuple[list[str], bool]] = []
+    health_calls: list[tuple[str, float]] = []
+
+    def fake_run(command: list[str], *, check: bool = True) -> Any:
+        calls.append((list(command), check))
+        if command[:2] == ["docker", "run"]:
+            return _completed(module, "container-id\n")
+        if command == ["docker", "port", "influx-smoke", "8086/tcp"]:
+            return _completed(module, "127.0.0.1:49153\n")
+        raise AssertionError(command)
+
+    def fake_health(url: str, timeout: float) -> dict[str, str]:
+        health_calls.append((url, timeout))
+        return {"status": "pass"}
+
+    container = module.start_influx_container(
+        image="influxdb:test",
+        container_name="influx-smoke",
+        org="org",
+        bucket="bucket",
+        username="user",
+        password="password",
+        token="token",
+        startup_timeout=12.5,
+        run_command=fake_run,
+        wait_for_health=fake_health,
+    )
+
+    run_command = calls[0][0]
+    assert run_command[:7] == [
+        "docker",
+        "run",
+        "--detach",
+        "--rm",
+        "--name",
+        "influx-smoke",
+        "--publish",
+    ]
+    assert "127.0.0.1::8086" in run_command
+    assert "DOCKER_INFLUXDB_INIT_MODE=setup" in run_command
+    assert "DOCKER_INFLUXDB_INIT_ORG=org" in run_command
+    assert "DOCKER_INFLUXDB_INIT_BUCKET=bucket" in run_command
+    assert "DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=token" in run_command
+    assert run_command[-1] == "influxdb:test"
+    assert health_calls == [("http://127.0.0.1:49153", 12.5)]
+    assert container.to_dict()["container_id"] == "container-id"
+    assert container.url == "http://127.0.0.1:49153"
+
+
+def test_write_and_verify_influx_uses_real_writer_contract() -> None:
+    """Smoke writes should flow through InfluxBatchWriter-compatible APIs."""
+    module = _module()
+    written_batches: list[list[str]] = []
+    query_calls: list[tuple[str, str]] = []
+
+    class FakeWriter:
+        def __init__(self, args: dict[str, str]) -> None:
+            self.args = args
+
+        def __enter__(self) -> "FakeWriter":
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+        def write_lines(self, lines: list[str]) -> None:
+            written_batches.append(lines)
+
+    class FakeRecord:
+        def __init__(self, value: int) -> None:
+            self.value = value
+
+        def get_value(self) -> int:
+            return self.value
+
+    class FakeTable:
+        records = [FakeRecord(4), FakeRecord(2)]
+
+    class FakeQueryApi:
+        def query(self, query: str, *, org: str) -> list[FakeTable]:
+            query_calls.append((query, org))
+            return [FakeTable()]
+
+    class FakeClient:
+        def __init__(self, **kwargs: str) -> None:
+            self.kwargs = kwargs
+
+        def __enter__(self) -> "FakeClient":
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+        def query_api(self) -> FakeQueryApi:
+            return FakeQueryApi()
+
+    report = module.write_and_verify_influx(
+        url="http://127.0.0.1:49153",
+        org="org",
+        bucket="bucket",
+        token="token",
+        writer_factory=FakeWriter,
+        client_factory=FakeClient,
+    )
+
+    assert written_batches == [[line] for line in module.SMOKE_LINES]
+    assert report["written_lines"] == 2
+    assert report["actual_field_count"] == 6
+    assert query_calls[0][1] == "org"
+    assert 'from(bucket: "bucket")' in query_calls[0][0]
+    assert 'r._measurement == "eurusd"' in query_calls[0][0]
+
+
+def test_run_docker_influx_smoke_cleans_up_container_on_success() -> None:
+    """Successful smoke runs should still remove the disposable container."""
+    module = _module()
+    calls: list[list[str]] = []
+
+    def fake_run(command: list[str], *, check: bool = True) -> Any:
+        calls.append(list(command))
+        if command[:2] == ["docker", "run"]:
+            return _completed(module, "container-id\n")
+        if command[:2] == ["docker", "port"]:
+            return _completed(module, "127.0.0.1:49153\n")
+        if command[:3] == ["docker", "rm", "--force"]:
+            return _completed(module, "influx-smoke\n")
+        raise AssertionError(command)
+
+    report = module.run_docker_influx_smoke(
+        image="influxdb:test",
+        container_name="influx-smoke",
+        run_command=fake_run,
+        wait_for_health=lambda url, timeout: {"status": "pass"},
+        writer_factory=lambda args: _NoopWriter(),
+        client_factory=lambda **kwargs: _CountClient(6),
+    )
+
+    assert report["status"] == "passed"
+    assert report["container"]["name"] == "influx-smoke"
+    assert ["docker", "rm", "--force", "influx-smoke"] in calls
+
+
+def test_run_docker_influx_smoke_includes_logs_on_failure() -> None:
+    """Failed live smokes should include Docker logs before cleanup."""
+    module = _module()
+    calls: list[list[str]] = []
+
+    def fake_run(command: list[str], *, check: bool = True) -> Any:
+        calls.append(list(command))
+        if command[:2] == ["docker", "run"]:
+            return _completed(module, "container-id\n")
+        if command[:2] == ["docker", "port"]:
+            return _completed(module, "127.0.0.1:49153\n")
+        if command[:2] == ["docker", "logs"]:
+            return _completed(module, "influx log\n")
+        if command[:3] == ["docker", "rm", "--force"]:
+            return _completed(module, "influx-smoke\n")
+        raise AssertionError(command)
+
+    try:
+        module.run_docker_influx_smoke(
+            image="influxdb:test",
+            container_name="influx-smoke",
+            run_command=fake_run,
+            wait_for_health=lambda url, timeout: {"status": "pass"},
+            writer_factory=lambda args: _NoopWriter(),
+            client_factory=lambda **kwargs: _CountClient(0),
+        )
+    except module.DockerInfluxSmokeError as err:
+        diagnostics = err.diagnostics
+    else:
+        raise AssertionError("expected DockerInfluxSmokeError")
+
+    assert diagnostics["logs"] == "influx log\n"
+    assert diagnostics["actual_field_count"] == 0
+    assert ["docker", "rm", "--force", "influx-smoke"] in calls
+
+
+class _NoopWriter:
+    def __enter__(self) -> "_NoopWriter":
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+    def write_lines(self, lines: list[str]) -> None:
+        return None
+
+
+class _CountClient:
+    def __init__(self, count: int) -> None:
+        self.count = count
+
+    def __enter__(self) -> "_CountClient":
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+    def query_api(self) -> "_CountClient":
+        return self
+
+    def query(self, query: str, *, org: str) -> list[Any]:
+        return [_CountTable(self.count)]
+
+
+class _CountTable:
+    def __init__(self, count: int) -> None:
+        self.records = [_CountRecord(count)]
+
+
+class _CountRecord:
+    def __init__(self, count: int) -> None:
+        self.count = count
+
+    def get_value(self) -> int:
+        return self.count


### PR DESCRIPTION
## Summary
- add `scripts/smoke_influx_docker.py` to start a disposable InfluxDB v2 container, write HistData-shaped line protocol through `InfluxBatchWriter`, query field counts, and clean up
- add hermetic unit coverage for the Docker harness command contract, write/query verification, success cleanup, and failure diagnostics
- document the Docker-backed smoke in README and Temporal sidecar operations/performance notes

Closes #218.

## Validation
- `venv/bin/python -m pytest -q tests/unit/test_smoke_influx_docker.py tests/unit/test_influx.py tests/unit/test_sidecar_influx_contract.py`
- `venv/bin/python -m compileall -q src tests scripts test.py snippets.py`
- `venv/bin/python -m pytest -q -rs`
- `venv/bin/python scripts/smoke_influx_docker.py --startup-timeout 90`
- `SKIP=no-commit-to-branch venv/bin/pre-commit run --all-files`
- `PATH="$PWD/venv/bin:$PATH" PYTHONNOUSERSITE=1 ./pypi.sh build`