### PR TITLE
Validate end-user CLI workflows

### DIFF
--- a/src/histdatacom/cli.py
+++ b/src/histdatacom/cli.py
@@ -332,6 +332,7 @@ class ArgParser(argparse.ArgumentParser):  # noqa:H601
         if self.arg_namespace.import_to_influxdb:
             self.arg_namespace.validate_urls = True
             self.arg_namespace.download_data_archives = True
+            self.arg_namespace.extract_csvs = True
 
         if (
             not self.arg_namespace.download_data_archives

--- a/src/histdatacom/histdata_com.py
+++ b/src/histdatacom/histdata_com.py
@@ -33,6 +33,7 @@ from typing import TYPE_CHECKING, Any, Mapping
 import histdatacom
 from histdatacom import Options
 from histdatacom.cli import ArgParser
+from histdatacom.exceptions import InfluxConfigurationError
 from histdatacom.repository_output import (
     print_repository_failure,
     print_repository_table,
@@ -49,6 +50,7 @@ from histdatacom.sidecar.cutover import (
     should_submit_to_sidecar,
 )
 from histdatacom.utils import (
+    load_influx_yaml,
     set_working_data_dir,
     normalize_api_return_type,
 )
@@ -226,6 +228,7 @@ def _resolve_runtime_context(options: Options) -> RuntimeContext:
     args["default_download_dir"] = set_working_data_dir(args["data_directory"])
     args["api_return_type"] = normalize_api_return_type(args["api_return_type"])
     options.api_return_type = args["api_return_type"]
+    _attach_influx_config_metadata(options, args)
     try:
         should_submit_to_sidecar(args)
     except ValueError as err:
@@ -246,6 +249,56 @@ def _resolve_runtime_context(options: Options) -> RuntimeContext:
         update_remote_data=bool(args["update_remote_data"]),
         import_to_influxdb=bool(args["import_to_influxdb"]),
     )
+
+
+def _attach_influx_config_metadata(
+    options: Options,
+    args: dict[str, Any],
+) -> None:
+    """Snapshot caller-local Influx config before sidecar handoff."""
+    if not bool(args.get("import_to_influxdb")):
+        return
+    metadata = dict(getattr(options, "metadata", {}) or {})
+    if isinstance(metadata.get("influx_config"), Mapping):
+        _validate_influx_metadata_config(metadata["influx_config"])
+        options.metadata = metadata
+        args["metadata"] = metadata
+        return
+    influx_yaml = load_influx_yaml()
+    influx_config = dict(influx_yaml.get("influxdb") or {})
+    missing = [
+        key
+        for key in ("org", "bucket", "url", "token")
+        if not influx_config.get(key)
+    ]
+    if missing:
+        missing_text = ", ".join(missing)
+        raise InfluxConfigurationError(
+            "influxdb.yaml is missing required influxdb keys: "
+            f"{missing_text}."
+        )
+    metadata["influx_config"] = {
+        "INFLUX_ORG": str(influx_config.get("org", "") or ""),
+        "INFLUX_BUCKET": str(influx_config.get("bucket", "") or ""),
+        "INFLUX_URL": str(influx_config.get("url", "") or ""),
+        "INFLUX_TOKEN": str(influx_config.get("token", "") or ""),
+    }
+    options.metadata = metadata
+    args["metadata"] = metadata
+
+
+def _validate_influx_metadata_config(config: Mapping[str, Any]) -> None:
+    """Validate serialized sidecar Influx connection keys."""
+    missing = [
+        key
+        for key in ("INFLUX_ORG", "INFLUX_BUCKET", "INFLUX_URL", "INFLUX_TOKEN")
+        if not config.get(key)
+    ]
+    if missing:
+        missing_text = ", ".join(missing)
+        raise InfluxConfigurationError(
+            "influx metadata is missing required keys: " f"{missing_text}."
+        )
 
 
 def _freeze_runtime_arg(value: Any) -> Any:

--- a/src/histdatacom/options.py
+++ b/src/histdatacom/options.py
@@ -38,3 +38,4 @@ class Options:
         self.use_sidecar: bool = True
         self.sidecar_start: bool = True
         self.sidecar_wait_result: bool = True
+        self.metadata: dict = {}

--- a/src/histdatacom/sidecar/activities.py
+++ b/src/histdatacom/sidecar/activities.py
@@ -553,11 +553,25 @@ def _repo_local_path(request: RunRequest) -> Path:
 
 
 def _influx_args(request: RunRequest) -> dict[str, Any]:
-    return {
+    args = {
         "default_download_dir": set_working_data_dir(request.data_directory),
         "batch_size": request.batch_size,
         "delete_after_influx": request.delete_after_influx,
     }
+    influx_config = request.metadata.get("influx_config")
+    if isinstance(influx_config, Mapping):
+        args.update(
+            {
+                key: str(influx_config.get(key, "") or "")
+                for key in (
+                    "INFLUX_ORG",
+                    "INFLUX_BUCKET",
+                    "INFLUX_URL",
+                    "INFLUX_TOKEN",
+                )
+            }
+        )
+    return args
 
 
 def _influx_batch_writer(args: Mapping[str, Any]) -> Any:

--- a/src/histdatacom/sidecar/cli.py
+++ b/src/histdatacom/sidecar/cli.py
@@ -200,6 +200,7 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="return after submission instead of waiting for the result",
     )
+    _add_job_command_common_args(submit, include_offline=False)
 
     list_jobs = job_subparsers.add_parser(
         "list",
@@ -216,6 +217,7 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         help="maximum stored jobs to return in offline/fallback mode",
     )
+    _add_job_command_common_args(list_jobs, include_offline=True)
 
     for command, help_text in (
         ("inspect", "inspect one sidecar job"),
@@ -229,6 +231,7 @@ def build_parser() -> argparse.ArgumentParser:
     ):
         job_parser = job_subparsers.add_parser(command, help=help_text)
         _add_job_identity_args(job_parser)
+        _add_job_command_common_args(job_parser, include_offline=True)
         if command in {"cancel", "retry", "resume"}:
             job_parser.add_argument(
                 "--reason",
@@ -364,6 +367,27 @@ def _add_job_identity_args(parser: argparse.ArgumentParser) -> None:
         default="",
         help="Temporal run ID when targeting a specific run",
     )
+
+
+def _add_job_command_common_args(
+    parser: argparse.ArgumentParser,
+    *,
+    include_offline: bool,
+) -> None:
+    """Accept shared jobs options after a job subcommand."""
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        default=argparse.SUPPRESS,
+        help="emit machine-readable JSON",
+    )
+    if include_offline:
+        parser.add_argument(
+            "--offline",
+            action="store_true",
+            default=argparse.SUPPRESS,
+            help="read persisted local job snapshots without querying Temporal",
+        )
 
 
 def _add_maintenance_args(parser: argparse.ArgumentParser) -> None:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -254,6 +254,7 @@ def test_argparser_bare_construction_uses_fresh_option_namespace(
     assert first_options.data_directory == str(first_data_dir)
     assert first_options.validate_urls
     assert first_options.download_data_archives
+    assert first_options.extract_csvs
     assert first_options.import_to_influxdb
     assert first_options.delete_after_influx
     assert not first_options.sidecar_start
@@ -337,7 +338,7 @@ def test_argparser_bare_construction_uses_fresh_option_namespace(
                 "update_remote_data": False,
                 "validate_urls": True,
                 "download_data_archives": True,
-                "extract_csvs": False,
+                "extract_csvs": True,
                 "import_to_influxdb": True,
             },
         ),

--- a/tests/unit/test_histdata_com.py
+++ b/tests/unit/test_histdata_com.py
@@ -9,6 +9,7 @@ from types import SimpleNamespace
 import pytest
 
 import histdatacom
+from histdatacom.exceptions import InfluxConfigurationError
 from histdatacom.options import Options
 from histdatacom.runtime_contracts import WorkStatus
 from histdatacom.sidecar.client import (
@@ -351,6 +352,19 @@ def test_back_to_back_cli_sidecar_requests_use_fresh_parser_state(
         "submit_run_request_and_observe_sync",
         fake_submit,
     )
+    (tmp_path / "influxdb.yaml").write_text(
+        "\n".join(
+            [
+                "influxdb:",
+                "  org: org",
+                "  bucket: bucket",
+                "  url: http://127.0.0.1:8086",
+                "  token: token",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(
         sys,
         "argv",
@@ -403,8 +417,14 @@ def test_back_to_back_cli_sidecar_requests_use_fresh_parser_state(
     assert first_request.pairs == ("eurusd",)
     assert first_request.timeframes == ("M1",)
     assert first_request.data_directory == str(tmp_path / "first")
+    assert first_request.validate_urls
+    assert first_request.download_data_archives
+    assert first_request.extract_csvs
     assert first_request.import_to_influxdb
     assert first_request.delete_after_influx
+    assert first_request.metadata["influx_config"]["INFLUX_BUCKET"] == (
+        "bucket"
+    )
     assert first_kwargs == {
         "start_if_needed": False,
         "wait_for_result": False,
@@ -599,6 +619,95 @@ def test_api_sidecar_repository_request_returns_available_data(
         "start_if_needed": True,
         "wait_for_result": True,
     }
+
+
+def test_influx_cli_config_is_captured_before_sidecar_handoff(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Influx imports should use the caller cwd, not the worker cwd."""
+    import histdatacom.histdata_com as histdata_com
+
+    (tmp_path / "influxdb.yaml").write_text(
+        "\n".join(
+            [
+                "influxdb:",
+                "  org: org",
+                "  bucket: bucket",
+                "  url: http://127.0.0.1:8086",
+                "  token: token",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    captured: dict[str, object] = {}
+
+    def fake_submit(request, **kwargs: object) -> SidecarJobResult:
+        captured["request"] = request
+        captured["kwargs"] = kwargs
+        return _job_result()
+
+    monkeypatch.setattr(
+        histdata_com,
+        "submit_run_request_and_observe_sync",
+        fake_submit,
+    )
+    options = _sidecar_options()
+    options.import_to_influxdb = True
+
+    histdata_com.main(options)
+
+    request = captured["request"]
+    assert request.validate_urls is True
+    assert request.download_data_archives is True
+    assert request.extract_csvs is True
+    assert request.import_to_influxdb is True
+    assert request.metadata["influx_config"] == {
+        "INFLUX_ORG": "org",
+        "INFLUX_BUCKET": "bucket",
+        "INFLUX_URL": "http://127.0.0.1:8086",
+        "INFLUX_TOKEN": "token",
+    }
+    assert captured["kwargs"] == {
+        "start_if_needed": True,
+        "wait_for_result": True,
+    }
+
+
+def test_influx_cli_config_validation_happens_before_sidecar_handoff(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Malformed Influx config should fail in the caller process."""
+    import histdatacom.histdata_com as histdata_com
+
+    (tmp_path / "influxdb.yaml").write_text(
+        "\n".join(
+            [
+                "influxdb:",
+                "  org: org",
+                "  bucket: bucket",
+                "  url: http://127.0.0.1:8086",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+
+    def fail_submit(*args: object, **kwargs: object) -> None:
+        raise AssertionError("malformed config should not submit to sidecar")
+
+    monkeypatch.setattr(
+        histdata_com,
+        "submit_run_request_and_observe_sync",
+        fail_submit,
+    )
+    options = _sidecar_options()
+    options.import_to_influxdb = True
+
+    with pytest.raises(InfluxConfigurationError, match="token"):
+        histdata_com.main(options)
 
 
 def test_api_sidecar_repository_failure_returns_available_data(

--- a/tests/unit/test_sidecar_activities.py
+++ b/tests/unit/test_sidecar_activities.py
@@ -242,6 +242,7 @@ def _influx_payload(
     timeframe: str = "M1",
     batch_size: str = "2",
     delete_after_influx: bool = False,
+    influx_config: dict | None = None,
 ) -> dict:
     """Return an Influx activity payload with a cache artifact."""
     filename = f"DAT_ASCII_EURUSD_{timeframe}_201202.csv"
@@ -259,6 +260,7 @@ def _influx_payload(
         batch_size=batch_size,
         import_to_influxdb=True,
         delete_after_influx=delete_after_influx,
+        metadata={"influx_config": influx_config} if influx_config else {},
     )
     return {
         "request": request.to_dict(),
@@ -839,6 +841,38 @@ def test_import_to_influx_activity_writes_m1_batches(
     assert result["result"]["metrics"]["line_count"] == 3
     assert result["result"]["metrics"]["heartbeat_count"] == 2
     assert "data" not in result
+
+
+def test_import_to_influx_activity_uses_request_influx_config(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    """Sidecar workers should use caller-resolved Influx connection config."""
+    FakeInfluxWriter.instances.clear()
+    FakeInfluxWriter.fail_with = None
+    monkeypatch.setattr(
+        "histdatacom.sidecar.activities._influx_batch_writer",
+        FakeInfluxWriter,
+    )
+
+    result = import_to_influx_activity(
+        _influx_payload(
+            tmp_path,
+            influx_config={
+                "INFLUX_ORG": "org",
+                "INFLUX_BUCKET": "bucket",
+                "INFLUX_URL": "http://127.0.0.1:8086",
+                "INFLUX_TOKEN": "token",
+            },
+        )
+    )
+
+    [writer] = FakeInfluxWriter.instances
+    assert writer.args["INFLUX_ORG"] == "org"
+    assert writer.args["INFLUX_BUCKET"] == "bucket"
+    assert writer.args["INFLUX_URL"] == "http://127.0.0.1:8086"
+    assert writer.args["INFLUX_TOKEN"] == "token"
+    assert result["result"]["status"] == WorkStatus.INFLUX_UPLOAD.value
 
 
 def test_import_to_influx_activity_writes_tick_batches(

--- a/tests/unit/test_sidecar_cli.py
+++ b/tests/unit/test_sidecar_cli.py
@@ -11,7 +11,11 @@ import pytest
 from histdatacom.runtime_contracts import RunRequest, WorkStatus
 from histdatacom.sidecar import client as sidecar_client
 from histdatacom.sidecar import cli
-from histdatacom.sidecar.control import JobLifecycle, SidecarJobSnapshot
+from histdatacom.sidecar.control import (
+    JobLifecycle,
+    SidecarJobList,
+    SidecarJobSnapshot,
+)
 from histdatacom.sidecar.queues import build_sidecar_worker_config
 from histdatacom.sidecar.runtime import build_sidecar_runtime_policy
 
@@ -349,6 +353,80 @@ def test_sidecar_jobs_cli_resolves_config_from_running_supervisor(
     assert isinstance(inspect_kwargs, dict)
     assert inspect_kwargs["config"] is resolved_config
     assert inspect_kwargs["supervisor"] is supervisor
+
+
+@pytest.mark.parametrize(
+    "argv",
+    (
+        ["jobs", "--json", "list"],
+        ["jobs", "list", "--json"],
+    ),
+)
+def test_sidecar_jobs_list_accepts_json_before_or_after_subcommand(
+    argv: list[str],
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Documented job commands should accept JSON flags naturally."""
+    monkeypatch.setattr(
+        cli,
+        "_supervisor",
+        lambda args: _StatusOnlySupervisor("running"),
+    )
+    monkeypatch.setattr(cli, "_worker_config", lambda args: _FakeConfig())
+    monkeypatch.setattr(
+        cli,
+        "list_job_statuses_sync",
+        lambda **kwargs: SidecarJobList(jobs=(_snapshot(),)),
+    )
+
+    exit_code = cli.main(argv)
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert payload["jobs"][0]["workflow_id"] == "histdatacom-run-cli"
+
+
+@pytest.mark.parametrize(
+    "argv",
+    (
+        ["jobs", "--json", "--offline", "inspect", "histdatacom-run-cli"],
+        ["jobs", "inspect", "histdatacom-run-cli", "--json", "--offline"],
+    ),
+)
+def test_sidecar_jobs_inspect_accepts_shared_flags_after_subcommand(
+    argv: list[str],
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Offline and JSON flags should work in documented user order."""
+    captured: dict[str, object] = {}
+
+    def fake_inspect(
+        workflow_id: str,
+        **kwargs: object,
+    ) -> SidecarJobSnapshot:
+        captured["workflow_id"] = workflow_id
+        captured["kwargs"] = kwargs
+        return _snapshot()
+
+    monkeypatch.setattr(
+        cli,
+        "_supervisor",
+        lambda args: _StatusOnlySupervisor("stopped"),
+    )
+    monkeypatch.setattr(cli, "_worker_config", lambda args: _FakeConfig())
+    monkeypatch.setattr(cli, "inspect_job_status_sync", fake_inspect)
+
+    exit_code = cli.main(argv)
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert payload["workflow_id"] == "histdatacom-run-cli"
+    assert captured["workflow_id"] == "histdatacom-run-cli"
+    kwargs = captured["kwargs"]
+    assert isinstance(kwargs, dict)
+    assert kwargs["offline"] is True
 
 
 def test_sidecar_jobs_offline_cli_reads_persisted_store(


### PR DESCRIPTION
## Summary
- make `-I/--import_to_influxdb` honor the documented validate/download/extract/import flow
- snapshot caller-local Influx config into sidecar request metadata before Temporal handoff
- accept `--json` and `--offline` after sidecar job subcommands as users naturally type them
- add regression coverage for Influx config handoff, malformed config, and sidecar job flag placement

## Validation
- `PYTHONNOUSERSITE=1 venv/bin/python -m pytest -q -rs` -> 465 passed, no pytest skips
- `PYTHONNOUSERSITE=1 venv/bin/python -m compileall -q src tests scripts test.py snippets.py`
- `PYTHONNOUSERSITE=1 SKIP=no-commit-to-branch venv/bin/pre-commit run --all-files`
- live end-user battery: help/version, sidecar status/doctor/jobs/maintenance, `-A`, `-U`, `-V`, `-D`, `-X`, default dataset operation, submit-only job inspection, and Docker-backed `-I` Influx import
- Docker-backed Influx readback confirmed `EURUSD` OHLC fields with 372,161 values per field
- `PYTHONNOUSERSITE=1 ./pypi.sh build` -> wheel/sdist build, twine check, wheel inspection, installed-wheel smoke all passed

## Notes
- Compared behavior against historical commit `1cd2a985ed4238fcd3355153a8bb8b7a2074dadd` as the pre-datatable-breakage functional baseline.
- The metadata-only wheel still reports no bundled Temporal executable; that is expected for this artifact and users can pass `--executable` for sidecar startup.