### PR TITLE
feat: add data quality report outputs

### DIFF
--- a/src/histdatacom/cli.py
+++ b/src/histdatacom/cli.py
@@ -76,6 +76,7 @@ from rich import print  # pylint: disable=redefined-builtin
 
 from histdatacom import Options
 from histdatacom.concurrency import get_pool_cpu_count
+from histdatacom.data_quality import QUALITY_CHECK_GROUPS
 from histdatacom.fx_enums import (
     Format,
     Pairs,
@@ -145,12 +146,67 @@ class ArgParser(argparse.ArgumentParser):  # noqa:H601
             self.arg_namespace.formats = {"ascii"}
             self.arg_namespace.timeframes = {"T"}
 
+    def _check_quality_mode(self) -> None:
+        """Validate local-only data quality mode inputs."""
+        if not self.arg_namespace.data_quality:
+            if self.arg_namespace.quality_paths:
+                print("--quality-target requires --quality")  # noqa:T201
+                raise SystemExit(1)
+            quality_groups = set(self.arg_namespace.quality_check_groups or ())
+            if quality_groups and quality_groups != {"all"}:
+                print("--quality-checks requires --quality")  # noqa:T201
+                raise SystemExit(1)
+            return
+
+        legacy_flags = {
+            "-A/--available_remote_data": (
+                self.arg_namespace.available_remote_data
+            ),
+            "-U/--update_remote_data": self.arg_namespace.update_remote_data,
+            "-V/--validate_urls": self.arg_namespace.validate_urls,
+            "-D/--download_data_archives": (
+                self.arg_namespace.download_data_archives
+            ),
+            "-X/--extract_csvs": self.arg_namespace.extract_csvs,
+            "-I/--import_to_influxdb": self.arg_namespace.import_to_influxdb,
+        }
+        conflicts = [flag for flag, enabled in legacy_flags.items() if enabled]
+        if conflicts:
+            print(  # noqa:T201
+                "--quality is a local-only operation and cannot be combined "
+                f"with {', '.join(conflicts)}"
+            )
+            raise SystemExit(1)
+
+        if not self.arg_namespace.quality_paths:
+            self.arg_namespace.quality_paths = (
+                self.arg_namespace.data_directory,
+            )
+
     def _clean_from_api_args(self) -> list:  # noqa:CCR001
         """Build the args list from api Options.
 
         Returns:
             list: args
         """
+        if self.arg_namespace.data_quality:
+            args = [
+                *["--data-directory", self.arg_namespace.data_directory],
+                "--quality",
+            ]
+            if self.arg_namespace.quality_paths:
+                args.extend(
+                    ["--quality-target", *self.arg_namespace.quality_paths]
+                )
+            if self.arg_namespace.quality_check_groups:
+                args.extend(
+                    [
+                        "--quality-checks",
+                        *sorted(self.arg_namespace.quality_check_groups),
+                    ]
+                )
+            return args
+
         self.arg_namespace.timeframes = Timeframe.convert_to_values(
             self.arg_namespace.timeframes
         )
@@ -224,7 +280,8 @@ class ArgParser(argparse.ArgumentParser):  # noqa:H601
         """
         try:
             if self.arg_namespace.from_api and not (
-                self.arg_namespace.validate_urls
+                self.arg_namespace.data_quality
+                or self.arg_namespace.validate_urls
                 or self.arg_namespace.download_data_archives
                 or self.arg_namespace.extract_csvs
                 or self.arg_namespace.import_to_influxdb
@@ -248,6 +305,9 @@ class ArgParser(argparse.ArgumentParser):  # noqa:H601
 
     def _check_for_supported_format_timeframe_combination(self) -> None:
         """Reject format/timeframe selections that generate no work."""
+        if self.arg_namespace.data_quality:
+            return
+
         formats = self.arg_namespace.formats or set()
         timeframes = self.arg_namespace.timeframes or set()
         has_supported_combination = any(
@@ -313,6 +373,9 @@ class ArgParser(argparse.ArgumentParser):  # noqa:H601
 
     def _validate_prerequisites(self) -> None:
         """Set prereqs for behavior flags -V -D -X -I."""
+        if self.arg_namespace.data_quality:
+            return
+
         if (
             self.arg_namespace.available_remote_data
             or self.arg_namespace.update_remote_data
@@ -699,6 +762,7 @@ class ArgParser(argparse.ArgumentParser):  # noqa:H601
         influx_args = self.add_argument_group("Influxdb")
         system_args = self.add_argument_group("System")
         sidecar_args = self.add_argument_group("Sidecar")
+        quality_args = self.add_argument_group("Data quality")
         info_args = self.add_argument_group("Info")
 
         info_args.add_argument(
@@ -871,6 +935,39 @@ class ArgParser(argparse.ArgumentParser):  # noqa:H601
             action="store_false",
             help="submit the sidecar job without waiting for its result",
         )
+        quality_args.add_argument(
+            "--quality",
+            dest="data_quality",
+            action="store_true",
+            help=(
+                "run offline data-quality target discovery against local "
+                "datasets without contacting HistData.com"
+            ),
+        )
+        quality_args.add_argument(
+            "--quality-target",
+            "--quality-path",
+            dest="quality_paths",
+            nargs="+",
+            type=str,
+            metavar="PATH",
+            help=(
+                "local file or directory to assess; supports directories, "
+                "HistData ZIP archives, CSV files, and .data cache files"
+            ),
+        )
+        quality_args.add_argument(
+            "--quality-checks",
+            dest="quality_check_groups",
+            nargs="+",
+            type=str,
+            choices=QUALITY_CHECK_GROUPS,
+            metavar="GROUP",
+            help=(
+                "quality check groups to run; defaults to all. Supported: "
+                + ", ".join(QUALITY_CHECK_GROUPS)
+            ),
+        )
 
     def _sanitize_input(self) -> None:  # noqa:DAR401
         """Clean user-input before run.
@@ -891,6 +988,7 @@ class ArgParser(argparse.ArgumentParser):  # noqa:H601
             self.parse_args(namespace=self.arg_namespace)
 
         self._adjust_for_repo_data_request()
+        self._check_quality_mode()
         self._check_datetime_input()
         self._check_for_ascii_if_influx()
         self._check_for_ascii_if_api()

--- a/src/histdatacom/cli.py
+++ b/src/histdatacom/cli.py
@@ -76,7 +76,7 @@ from rich import print  # pylint: disable=redefined-builtin
 
 from histdatacom import Options
 from histdatacom.concurrency import get_pool_cpu_count
-from histdatacom.data_quality import QUALITY_CHECK_GROUPS
+from histdatacom.data_quality import QUALITY_CHECK_GROUPS, QUALITY_EXIT_TRIGGERS
 from histdatacom.fx_enums import (
     Format,
     Pairs,
@@ -89,6 +89,19 @@ from histdatacom.utils import (
     get_month_from_datemonth,
     replace_date_punct,
 )
+
+
+def _non_negative_int(value: str) -> int:
+    """Return a non-negative integer for argparse thresholds."""
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            f"{value!r} is not an integer"
+        ) from exc
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("value must be non-negative")
+    return parsed
 
 
 class ArgParser(argparse.ArgumentParser):  # noqa:H601
@@ -156,6 +169,18 @@ class ArgParser(argparse.ArgumentParser):  # noqa:H601
             if quality_groups and quality_groups != {"all"}:
                 print("--quality-checks requires --quality")  # noqa:T201
                 raise SystemExit(1)
+            if self.arg_namespace.quality_report_path:
+                print("--quality-report requires --quality")  # noqa:T201
+                raise SystemExit(1)
+            if self.arg_namespace.quality_fail_on != "error":
+                print("--quality-fail-on requires --quality")  # noqa:T201
+                raise SystemExit(1)
+            if self.arg_namespace.quality_max_errors != 0:
+                print("--quality-max-errors requires --quality")  # noqa:T201
+                raise SystemExit(1)
+            if self.arg_namespace.quality_max_warnings != 0:
+                print("--quality-max-warnings requires --quality")  # noqa:T201
+                raise SystemExit(1)
             return
 
         legacy_flags = {
@@ -205,6 +230,25 @@ class ArgParser(argparse.ArgumentParser):  # noqa:H601
                         *sorted(self.arg_namespace.quality_check_groups),
                     ]
                 )
+            if self.arg_namespace.quality_report_path:
+                args.extend(
+                    ["--quality-report", self.arg_namespace.quality_report_path]
+                )
+            args.extend(
+                ["--quality-fail-on", self.arg_namespace.quality_fail_on]
+            )
+            args.extend(
+                [
+                    "--quality-max-errors",
+                    str(self.arg_namespace.quality_max_errors),
+                ]
+            )
+            args.extend(
+                [
+                    "--quality-max-warnings",
+                    str(self.arg_namespace.quality_max_warnings),
+                ]
+            )
             return args
 
         self.arg_namespace.timeframes = Timeframe.convert_to_values(
@@ -940,8 +984,8 @@ class ArgParser(argparse.ArgumentParser):  # noqa:H601
             dest="data_quality",
             action="store_true",
             help=(
-                "run offline data-quality target discovery against local "
-                "datasets without contacting HistData.com"
+                "run offline data-quality assessment against local datasets "
+                "without contacting HistData.com"
             ),
         )
         quality_args.add_argument(
@@ -966,6 +1010,45 @@ class ArgParser(argparse.ArgumentParser):  # noqa:H601
             help=(
                 "quality check groups to run; defaults to all. Supported: "
                 + ", ".join(QUALITY_CHECK_GROUPS)
+            ),
+        )
+        quality_args.add_argument(
+            "--quality-report",
+            dest="quality_report_path",
+            type=str,
+            metavar="PATH",
+            help="write the full machine-readable JSON quality report to PATH",
+        )
+        quality_args.add_argument(
+            "--quality-fail-on",
+            dest="quality_fail_on",
+            type=str,
+            choices=QUALITY_EXIT_TRIGGERS,
+            metavar="SEVERITY",
+            help=(
+                "exit non-zero when configured thresholds are exceeded for "
+                "error, warning, or never. Defaults to error"
+            ),
+        )
+        quality_args.add_argument(
+            "--quality-max-errors",
+            dest="quality_max_errors",
+            type=_non_negative_int,
+            metavar="COUNT",
+            help=(
+                "maximum error findings allowed before quality mode exits "
+                "non-zero; defaults to 0"
+            ),
+        )
+        quality_args.add_argument(
+            "--quality-max-warnings",
+            dest="quality_max_warnings",
+            type=_non_negative_int,
+            metavar="COUNT",
+            help=(
+                "maximum warning findings allowed before quality mode exits "
+                "non-zero when --quality-fail-on warning is selected; "
+                "defaults to 0"
             ),
         )
 

--- a/src/histdatacom/cli.py
+++ b/src/histdatacom/cli.py
@@ -332,6 +332,7 @@ class ArgParser(argparse.ArgumentParser):  # noqa:H601
         if self.arg_namespace.import_to_influxdb:
             self.arg_namespace.validate_urls = True
             self.arg_namespace.download_data_archives = True
+            self.arg_namespace.extract_csvs = True
 
         if (
             not self.arg_namespace.download_data_archives

--- a/src/histdatacom/data_quality/__init__.py
+++ b/src/histdatacom/data_quality/__init__.py
@@ -27,11 +27,28 @@ from histdatacom.data_quality.engine import (
     evaluate_quality_rule,
     run_quality_assessment,
 )
+from histdatacom.data_quality.reporting import (
+    QUALITY_EXIT_TRIGGERS,
+    QUALITY_REPORT_SCHEMA_VERSION,
+    QualityExitDecision,
+    QualityExitPolicy,
+    QualityExitTrigger,
+    bounded_quality_payload,
+    format_quality_console_summary,
+    quality_report_payload,
+    quality_report_to_json,
+    write_quality_report,
+)
 
 __all__ = [
+    "QUALITY_EXIT_TRIGGERS",
+    "QUALITY_REPORT_SCHEMA_VERSION",
     "QualityFinding",
     "QualityDiscoveryError",
     "QualityDiscoveryResult",
+    "QualityExitDecision",
+    "QualityExitPolicy",
+    "QualityExitTrigger",
     "QualityLocation",
     "QualityReport",
     "QualityRule",
@@ -43,9 +60,14 @@ __all__ = [
     "QualityTargetKind",
     "QualityTargetSummary",
     "QUALITY_CHECK_GROUPS",
+    "bounded_quality_payload",
     "discover_quality_targets",
     "evaluate_quality_rule",
+    "format_quality_console_summary",
     "normalize_quality_check_groups",
+    "quality_report_payload",
+    "quality_report_to_json",
     "quality_target_from_path",
     "run_quality_assessment",
+    "write_quality_report",
 ]

--- a/src/histdatacom/data_quality/__init__.py
+++ b/src/histdatacom/data_quality/__init__.py
@@ -15,6 +15,14 @@ from histdatacom.data_quality.contracts import (
     QualityTargetKind,
     QualityTargetSummary,
 )
+from histdatacom.data_quality.discovery import (
+    QUALITY_CHECK_GROUPS,
+    QualityDiscoveryError,
+    QualityDiscoveryResult,
+    discover_quality_targets,
+    normalize_quality_check_groups,
+    quality_target_from_path,
+)
 from histdatacom.data_quality.engine import (
     evaluate_quality_rule,
     run_quality_assessment,
@@ -22,6 +30,8 @@ from histdatacom.data_quality.engine import (
 
 __all__ = [
     "QualityFinding",
+    "QualityDiscoveryError",
+    "QualityDiscoveryResult",
     "QualityLocation",
     "QualityReport",
     "QualityRule",
@@ -32,6 +42,10 @@ __all__ = [
     "QualityTarget",
     "QualityTargetKind",
     "QualityTargetSummary",
+    "QUALITY_CHECK_GROUPS",
+    "discover_quality_targets",
     "evaluate_quality_rule",
+    "normalize_quality_check_groups",
+    "quality_target_from_path",
     "run_quality_assessment",
 ]

--- a/src/histdatacom/data_quality/__init__.py
+++ b/src/histdatacom/data_quality/__init__.py
@@ -1,0 +1,37 @@
+"""Data-quality assessment contracts and orchestration helpers."""
+
+from __future__ import annotations
+
+from histdatacom.data_quality.contracts import (
+    QualityFinding,
+    QualityLocation,
+    QualityReport,
+    QualityRule,
+    QualityRuleResult,
+    QualityRunSummary,
+    QualitySeverity,
+    QualityStatus,
+    QualityTarget,
+    QualityTargetKind,
+    QualityTargetSummary,
+)
+from histdatacom.data_quality.engine import (
+    evaluate_quality_rule,
+    run_quality_assessment,
+)
+
+__all__ = [
+    "QualityFinding",
+    "QualityLocation",
+    "QualityReport",
+    "QualityRule",
+    "QualityRuleResult",
+    "QualityRunSummary",
+    "QualitySeverity",
+    "QualityStatus",
+    "QualityTarget",
+    "QualityTargetKind",
+    "QualityTargetSummary",
+    "evaluate_quality_rule",
+    "run_quality_assessment",
+]

--- a/src/histdatacom/data_quality/contracts.py
+++ b/src/histdatacom/data_quality/contracts.py
@@ -1,0 +1,542 @@
+"""Serializable contracts for HistData data-quality assessments."""
+
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Protocol
+
+from histdatacom.runtime_contracts import JSONValue
+
+
+class QualitySeverity(str, Enum):
+    """Severity levels emitted by data-quality checks."""
+
+    INFO = "info"
+    WARNING = "warning"
+    ERROR = "error"
+
+    @classmethod
+    def from_value(
+        cls, value: str | "QualitySeverity" | None
+    ) -> "QualitySeverity":
+        """Normalize a public severity value."""
+        if isinstance(value, cls):
+            return value
+
+        normalized = str(value or "").strip().lower()
+        if not normalized:
+            return cls.INFO
+
+        aliases = {
+            "warn": cls.WARNING,
+            "failed": cls.ERROR,
+            "failure": cls.ERROR,
+            "fatal": cls.ERROR,
+            "fail": cls.ERROR,
+        }
+        if normalized in aliases:
+            return aliases[normalized]
+
+        try:
+            return cls(normalized)
+        except ValueError as exc:
+            msg = f"unknown quality severity: {value!r}"
+            raise ValueError(msg) from exc
+
+    @property
+    def rank(self) -> int:
+        """Return severity order for aggregation."""
+        return {
+            self.INFO: 0,
+            self.WARNING: 1,
+            self.ERROR: 2,
+        }[self]
+
+    @classmethod
+    def max(
+        cls, severities: Iterable[str | "QualitySeverity" | None]
+    ) -> "QualitySeverity":
+        """Return the highest severity in an iterable."""
+        highest = cls.INFO
+        for severity in severities:
+            candidate = cls.from_value(severity)
+            if candidate.rank > highest.rank:
+                highest = candidate
+        return highest
+
+
+class QualityStatus(str, Enum):
+    """Aggregate pass/warning/fail status for quality output."""
+
+    CLEAN = "clean"
+    WARNING = "warning"
+    FAILED = "failed"
+
+    @classmethod
+    def from_value(cls, value: str | "QualityStatus" | None) -> "QualityStatus":
+        """Normalize a public status value."""
+        if isinstance(value, cls):
+            return value
+
+        normalized = str(value or "").strip().lower()
+        if not normalized:
+            return cls.CLEAN
+
+        aliases = {
+            "ok": cls.CLEAN,
+            "pass": cls.CLEAN,
+            "passed": cls.CLEAN,
+            "success": cls.CLEAN,
+            "error": cls.FAILED,
+            "fail": cls.FAILED,
+            "failure": cls.FAILED,
+        }
+        if normalized in aliases:
+            return aliases[normalized]
+
+        try:
+            return cls(normalized)
+        except ValueError as exc:
+            msg = f"unknown quality status: {value!r}"
+            raise ValueError(msg) from exc
+
+    @classmethod
+    def from_severity_counts(
+        cls,
+        *,
+        warning_count: int = 0,
+        error_count: int = 0,
+    ) -> "QualityStatus":
+        """Return aggregate status from warning and error counts."""
+        if error_count:
+            return cls.FAILED
+        if warning_count:
+            return cls.WARNING
+        return cls.CLEAN
+
+
+class QualityTargetKind(str, Enum):
+    """Kind of artifact being assessed."""
+
+    UNKNOWN = "unknown"
+    DIRECTORY = "directory"
+    ZIP = "zip"
+    CSV = "csv"
+    CACHE = "cache"
+
+    @classmethod
+    def from_value(
+        cls, value: str | "QualityTargetKind" | None
+    ) -> "QualityTargetKind":
+        """Normalize an artifact kind value."""
+        if isinstance(value, cls):
+            return value
+
+        normalized = str(value or "").strip().lower().replace("_", "-")
+        if not normalized:
+            return cls.UNKNOWN
+
+        aliases = {
+            "dir": cls.DIRECTORY,
+            "folder": cls.DIRECTORY,
+            "archive": cls.ZIP,
+            "zipfile": cls.ZIP,
+            "zip-file": cls.ZIP,
+            "csv-file": cls.CSV,
+            "file": cls.CSV,
+            "polars-cache": cls.CACHE,
+            "cache-file": cls.CACHE,
+            "parquet": cls.CACHE,
+        }
+        if normalized in aliases:
+            return aliases[normalized]
+
+        try:
+            return cls(normalized)
+        except ValueError:
+            return cls.UNKNOWN
+
+
+@dataclass(frozen=True, slots=True)
+class QualityTarget:
+    """A ZIP, CSV, cache, or directory target for quality checks."""
+
+    path: str
+    kind: QualityTargetKind = QualityTargetKind.UNKNOWN
+    data_format: str = ""
+    timeframe: str = ""
+    symbol: str = ""
+    period: str = ""
+    metadata: dict[str, JSONValue] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, JSONValue]:
+        """Return a JSON-compatible representation."""
+        return {
+            "path": self.path,
+            "kind": self.kind.value,
+            "data_format": self.data_format,
+            "timeframe": self.timeframe,
+            "symbol": self.symbol,
+            "period": self.period,
+            "metadata": dict(self.metadata),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "QualityTarget":
+        """Create a quality target from JSON-compatible data."""
+        return cls(
+            path=str(data.get("path", "")),
+            kind=QualityTargetKind.from_value(data.get("kind")),
+            data_format=str(data.get("data_format", "") or ""),
+            timeframe=str(data.get("timeframe", "") or ""),
+            symbol=str(data.get("symbol", "") or ""),
+            period=str(data.get("period", "") or ""),
+            metadata=dict(data.get("metadata") or {}),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class QualityLocation:
+    """Optional record-level context for a quality finding."""
+
+    path: str = ""
+    row_number: int | None = None
+    timestamp_source: str = ""
+    timestamp_utc_ms: int | None = None
+    column: str = ""
+    metadata: dict[str, JSONValue] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, JSONValue]:
+        """Return a JSON-compatible representation."""
+        return {
+            "path": self.path,
+            "row_number": self.row_number,
+            "timestamp_source": self.timestamp_source,
+            "timestamp_utc_ms": self.timestamp_utc_ms,
+            "column": self.column,
+            "metadata": dict(self.metadata),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any] | None) -> "QualityLocation":
+        """Create a location from JSON-compatible data."""
+        data = data or {}
+        row_number = data.get("row_number")
+        timestamp_utc_ms = data.get("timestamp_utc_ms")
+        return cls(
+            path=str(data.get("path", "") or ""),
+            row_number=(None if row_number is None else int(row_number)),
+            timestamp_source=str(data.get("timestamp_source", "") or ""),
+            timestamp_utc_ms=(
+                None if timestamp_utc_ms is None else int(timestamp_utc_ms)
+            ),
+            column=str(data.get("column", "") or ""),
+            metadata=dict(data.get("metadata") or {}),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class QualityFinding:
+    """A structured finding emitted by one quality check."""
+
+    severity: QualitySeverity
+    code: str
+    message: str
+    rule_id: str
+    target: QualityTarget
+    location: QualityLocation = field(default_factory=QualityLocation)
+    metadata: dict[str, JSONValue] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, JSONValue]:
+        """Return a JSON-compatible representation."""
+        return {
+            "severity": self.severity.value,
+            "code": self.code,
+            "message": self.message,
+            "rule_id": self.rule_id,
+            "target": self.target.to_dict(),
+            "location": self.location.to_dict(),
+            "metadata": dict(self.metadata),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "QualityFinding":
+        """Create a quality finding from JSON-compatible data."""
+        return cls(
+            severity=QualitySeverity.from_value(data.get("severity")),
+            code=str(data.get("code", "") or ""),
+            message=str(data.get("message", "") or ""),
+            rule_id=str(data.get("rule_id", "") or ""),
+            target=QualityTarget.from_dict(data.get("target") or {}),
+            location=QualityLocation.from_dict(data.get("location")),
+            metadata=dict(data.get("metadata") or {}),
+        )
+
+
+class QualityRule(Protocol):
+    """Protocol implemented by concrete data-quality checks."""
+
+    rule_id: str
+    description: str
+
+    def evaluate(self, target: QualityTarget) -> Iterable[QualityFinding]:
+        """Return findings for one target."""
+
+
+def _severity_counts(
+    findings: Iterable[QualityFinding],
+) -> Counter[QualitySeverity]:
+    """Return finding counts keyed by normalized severity."""
+    return Counter(finding.severity for finding in findings)
+
+
+def _status_from_findings(findings: Iterable[QualityFinding]) -> QualityStatus:
+    """Return aggregate status for a finding iterable."""
+    counts = _severity_counts(findings)
+    return QualityStatus.from_severity_counts(
+        warning_count=counts[QualitySeverity.WARNING],
+        error_count=counts[QualitySeverity.ERROR],
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class QualityRuleResult:
+    """Findings produced by one rule for one target."""
+
+    rule_id: str
+    target: QualityTarget
+    findings: tuple[QualityFinding, ...] = ()
+
+    @property
+    def status(self) -> QualityStatus:
+        """Return aggregate status for this rule result."""
+        return _status_from_findings(self.findings)
+
+    @property
+    def max_severity(self) -> QualitySeverity:
+        """Return the highest finding severity for this rule result."""
+        return QualitySeverity.max(
+            finding.severity for finding in self.findings
+        )
+
+    def to_dict(self) -> dict[str, JSONValue]:
+        """Return a JSON-compatible representation."""
+        return {
+            "rule_id": self.rule_id,
+            "target": self.target.to_dict(),
+            "findings": [finding.to_dict() for finding in self.findings],
+            "status": self.status.value,
+            "max_severity": self.max_severity.value,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "QualityRuleResult":
+        """Create a rule result from JSON-compatible data."""
+        return cls(
+            rule_id=str(data.get("rule_id", "") or ""),
+            target=QualityTarget.from_dict(data.get("target") or {}),
+            findings=tuple(
+                QualityFinding.from_dict(finding)
+                for finding in data.get("findings", ())
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class QualityTargetSummary:
+    """Aggregate data-quality result for one assessed target."""
+
+    target: QualityTarget
+    rule_count: int
+    finding_count: int
+    info_count: int
+    warning_count: int
+    error_count: int
+    status: QualityStatus
+    max_severity: QualitySeverity
+
+    def to_dict(self) -> dict[str, JSONValue]:
+        """Return a JSON-compatible representation."""
+        return {
+            "target": self.target.to_dict(),
+            "rule_count": self.rule_count,
+            "finding_count": self.finding_count,
+            "info_count": self.info_count,
+            "warning_count": self.warning_count,
+            "error_count": self.error_count,
+            "status": self.status.value,
+            "max_severity": self.max_severity.value,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "QualityTargetSummary":
+        """Create a target summary from JSON-compatible data."""
+        return cls(
+            target=QualityTarget.from_dict(data.get("target") or {}),
+            rule_count=int(data.get("rule_count", 0) or 0),
+            finding_count=int(data.get("finding_count", 0) or 0),
+            info_count=int(data.get("info_count", 0) or 0),
+            warning_count=int(data.get("warning_count", 0) or 0),
+            error_count=int(data.get("error_count", 0) or 0),
+            status=QualityStatus.from_value(data.get("status")),
+            max_severity=QualitySeverity.from_value(data.get("max_severity")),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class QualityRunSummary:
+    """Aggregate data-quality result for an assessment run."""
+
+    target_count: int
+    rule_count: int
+    finding_count: int
+    info_count: int
+    warning_count: int
+    error_count: int
+    status: QualityStatus
+    max_severity: QualitySeverity
+
+    def to_dict(self) -> dict[str, JSONValue]:
+        """Return a JSON-compatible representation."""
+        return {
+            "target_count": self.target_count,
+            "rule_count": self.rule_count,
+            "finding_count": self.finding_count,
+            "info_count": self.info_count,
+            "warning_count": self.warning_count,
+            "error_count": self.error_count,
+            "status": self.status.value,
+            "max_severity": self.max_severity.value,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "QualityRunSummary":
+        """Create a run summary from JSON-compatible data."""
+        return cls(
+            target_count=int(data.get("target_count", 0) or 0),
+            rule_count=int(data.get("rule_count", 0) or 0),
+            finding_count=int(data.get("finding_count", 0) or 0),
+            info_count=int(data.get("info_count", 0) or 0),
+            warning_count=int(data.get("warning_count", 0) or 0),
+            error_count=int(data.get("error_count", 0) or 0),
+            status=QualityStatus.from_value(data.get("status")),
+            max_severity=QualitySeverity.from_value(data.get("max_severity")),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class QualityReport:
+    """Complete data-quality assessment output."""
+
+    targets: tuple[QualityTarget, ...] = ()
+    rule_results: tuple[QualityRuleResult, ...] = ()
+    metadata: dict[str, JSONValue] = field(default_factory=dict)
+
+    @property
+    def findings(self) -> tuple[QualityFinding, ...]:
+        """Return all findings in target/rule evaluation order."""
+        return tuple(
+            finding
+            for result in self.rule_results
+            for finding in result.findings
+        )
+
+    @property
+    def status(self) -> QualityStatus:
+        """Return aggregate run status."""
+        return _status_from_findings(self.findings)
+
+    @property
+    def max_severity(self) -> QualitySeverity:
+        """Return the highest finding severity in the run."""
+        return QualitySeverity.max(
+            finding.severity for finding in self.findings
+        )
+
+    @property
+    def rule_count(self) -> int:
+        """Return the number of distinct evaluated rules."""
+        return len({result.rule_id for result in self.rule_results})
+
+    @property
+    def target_summaries(self) -> tuple[QualityTargetSummary, ...]:
+        """Return per-target aggregate summaries."""
+        summaries = []
+        for target in self.targets:
+            results = tuple(
+                result
+                for result in self.rule_results
+                if result.target == target
+            )
+            findings = tuple(
+                finding for result in results for finding in result.findings
+            )
+            counts = _severity_counts(findings)
+            summaries.append(
+                QualityTargetSummary(
+                    target=target,
+                    rule_count=len({result.rule_id for result in results}),
+                    finding_count=len(findings),
+                    info_count=counts[QualitySeverity.INFO],
+                    warning_count=counts[QualitySeverity.WARNING],
+                    error_count=counts[QualitySeverity.ERROR],
+                    status=QualityStatus.from_severity_counts(
+                        warning_count=counts[QualitySeverity.WARNING],
+                        error_count=counts[QualitySeverity.ERROR],
+                    ),
+                    max_severity=QualitySeverity.max(
+                        finding.severity for finding in findings
+                    ),
+                )
+            )
+        return tuple(summaries)
+
+    def summary(self) -> QualityRunSummary:
+        """Return aggregate run counts and status."""
+        findings = self.findings
+        counts = _severity_counts(findings)
+        return QualityRunSummary(
+            target_count=len(self.targets),
+            rule_count=self.rule_count,
+            finding_count=len(findings),
+            info_count=counts[QualitySeverity.INFO],
+            warning_count=counts[QualitySeverity.WARNING],
+            error_count=counts[QualitySeverity.ERROR],
+            status=QualityStatus.from_severity_counts(
+                warning_count=counts[QualitySeverity.WARNING],
+                error_count=counts[QualitySeverity.ERROR],
+            ),
+            max_severity=QualitySeverity.max(
+                finding.severity for finding in findings
+            ),
+        )
+
+    def to_dict(self) -> dict[str, JSONValue]:
+        """Return a JSON-compatible representation."""
+        return {
+            "targets": [target.to_dict() for target in self.targets],
+            "rule_results": [result.to_dict() for result in self.rule_results],
+            "target_summaries": [
+                summary.to_dict() for summary in self.target_summaries
+            ],
+            "summary": self.summary().to_dict(),
+            "metadata": dict(self.metadata),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "QualityReport":
+        """Create a quality report from JSON-compatible data."""
+        return cls(
+            targets=tuple(
+                QualityTarget.from_dict(target)
+                for target in data.get("targets", ())
+            ),
+            rule_results=tuple(
+                QualityRuleResult.from_dict(result)
+                for result in data.get("rule_results", ())
+            ),
+            metadata=dict(data.get("metadata") or {}),
+        )

--- a/src/histdatacom/data_quality/discovery.py
+++ b/src/histdatacom/data_quality/discovery.py
@@ -1,0 +1,211 @@
+"""Local target discovery for offline data-quality assessments."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+import re
+from typing import Any
+
+from histdatacom.data_quality.contracts import (
+    QualityTarget,
+    QualityTargetKind,
+)
+from histdatacom.histdata_ascii import CACHE_FILENAME, M1, TICK
+from histdatacom.runtime_contracts import JSONValue
+
+QUALITY_CHECK_GROUPS = (
+    "all",
+    "inventory",
+    "ingestion",
+    "time",
+    "bars",
+    "ticks",
+    "domain",
+    "modeling",
+)
+
+_ASCII_FILENAME_RE = re.compile(
+    r"^DAT_ASCII_(?P<symbol>[A-Z0-9]+)_(?P<timeframe>M1|T)_"
+    r"(?P<period>\d{6})(?:_[A-Z0-9_]+)?(?:\.csv)?$",
+    re.IGNORECASE,
+)
+
+
+class QualityDiscoveryError(ValueError):
+    """Raised when local quality target discovery cannot continue."""
+
+
+@dataclass(frozen=True, slots=True)
+class QualityDiscoveryResult:
+    """Result of scanning local filesystem paths for quality targets."""
+
+    roots: tuple[str, ...] = ()
+    targets: tuple[QualityTarget, ...] = ()
+    metadata: dict[str, JSONValue] = field(default_factory=dict)
+
+    @property
+    def target_count(self) -> int:
+        """Return the number of discovered targets."""
+        return len(self.targets)
+
+    def to_dict(self) -> dict[str, JSONValue]:
+        """Return a JSON-compatible representation."""
+        return {
+            "roots": list(self.roots),
+            "target_count": self.target_count,
+            "targets": [target.to_dict() for target in self.targets],
+            "metadata": dict(self.metadata),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "QualityDiscoveryResult":
+        """Create a discovery result from JSON-compatible data."""
+        return cls(
+            roots=tuple(str(root) for root in data.get("roots", ())),
+            targets=tuple(
+                QualityTarget.from_dict(target)
+                for target in data.get("targets", ())
+            ),
+            metadata=dict(data.get("metadata") or {}),
+        )
+
+
+def normalize_quality_check_groups(
+    groups: Iterable[str] | None,
+) -> tuple[str, ...]:
+    """Return stable quality check group selections."""
+    normalized = tuple(
+        dict.fromkeys(
+            str(group).strip().lower()
+            for group in (groups or ("all",))
+            if str(group).strip()
+        )
+    )
+    if not normalized:
+        return ("all",)
+
+    unsupported = sorted(set(normalized).difference(QUALITY_CHECK_GROUPS))
+    if unsupported:
+        msg = "unsupported quality check group(s): " + ", ".join(unsupported)
+        raise QualityDiscoveryError(msg)
+
+    if "all" in normalized and len(normalized) > 1:
+        msg = "--quality-checks all cannot be combined with specific groups"
+        raise QualityDiscoveryError(msg)
+
+    return normalized
+
+
+def discover_quality_targets(
+    paths: Iterable[str | Path],
+) -> QualityDiscoveryResult:
+    """Discover ZIP, CSV, and cache targets from local filesystem paths."""
+    roots = _normalize_roots(paths)
+    seen_paths: set[str] = set()
+    targets: list[QualityTarget] = []
+
+    for root in roots:
+        if not root.exists():
+            raise QualityDiscoveryError(
+                f"quality target path does not exist: {root}"
+            )
+        if root.is_dir():
+            candidates = sorted(
+                path for path in root.rglob("*") if path.is_file()
+            )
+        elif root.is_file():
+            candidates = [root]
+        else:
+            raise QualityDiscoveryError(
+                f"quality target path is not a file or directory: {root}"
+            )
+
+        for candidate in candidates:
+            target = quality_target_from_path(candidate)
+            if target is None:
+                if root == candidate:
+                    raise QualityDiscoveryError(
+                        "unsupported quality target file type: " f"{candidate}"
+                    )
+                continue
+            resolved = str(candidate.resolve())
+            if resolved in seen_paths:
+                continue
+            seen_paths.add(resolved)
+            targets.append(target)
+
+    return QualityDiscoveryResult(
+        roots=tuple(str(root) for root in roots),
+        targets=tuple(sorted(targets, key=lambda target: target.path)),
+        metadata={"supported_kinds": [kind.value for kind in _TARGET_KINDS]},
+    )
+
+
+def quality_target_from_path(path: str | Path) -> QualityTarget | None:
+    """Return a quality target for a supported file path, if any."""
+    source = Path(path)
+    kind = _target_kind(source)
+    if kind is None:
+        return None
+
+    metadata = _metadata_from_filename(source)
+    metadata["filename"] = source.name
+    return QualityTarget(
+        path=str(source.resolve()),
+        kind=kind,
+        data_format=str(metadata.get("data_format", "") or ""),
+        timeframe=str(metadata.get("timeframe", "") or ""),
+        symbol=str(metadata.get("symbol", "") or ""),
+        period=str(metadata.get("period", "") or ""),
+        metadata=metadata,
+    )
+
+
+def _normalize_roots(paths: Iterable[str | Path]) -> tuple[Path, ...]:
+    roots = tuple(Path(path).expanduser() for path in paths)
+    if not roots:
+        raise QualityDiscoveryError(
+            "at least one quality target path is required"
+        )
+    return roots
+
+
+def _target_kind(path: Path) -> QualityTargetKind | None:
+    if path.name == CACHE_FILENAME:
+        return QualityTargetKind.CACHE
+    suffix = path.suffix.lower()
+    if suffix == ".zip":
+        return QualityTargetKind.ZIP
+    if suffix == ".csv":
+        return QualityTargetKind.CSV
+    return None
+
+
+def _metadata_from_filename(path: Path) -> dict[str, JSONValue]:
+    filename = path.name
+    if path.suffix.lower() == ".zip":
+        filename = path.with_suffix("").name
+
+    match = _ASCII_FILENAME_RE.match(filename)
+    if match is None:
+        return {}
+
+    timeframe = match.group("timeframe").upper()
+    if timeframe not in {M1, TICK}:
+        return {}
+
+    return {
+        "data_format": "ascii",
+        "symbol": match.group("symbol").upper(),
+        "timeframe": timeframe,
+        "period": match.group("period"),
+    }
+
+
+_TARGET_KINDS = (
+    QualityTargetKind.ZIP,
+    QualityTargetKind.CSV,
+    QualityTargetKind.CACHE,
+)

--- a/src/histdatacom/data_quality/engine.py
+++ b/src/histdatacom/data_quality/engine.py
@@ -1,0 +1,45 @@
+"""Rule orchestration for HistData data-quality assessments."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+
+from histdatacom.data_quality.contracts import (
+    QualityReport,
+    QualityRule,
+    QualityRuleResult,
+    QualityTarget,
+)
+from histdatacom.runtime_contracts import JSONValue
+
+
+def evaluate_quality_rule(
+    rule: QualityRule,
+    target: QualityTarget,
+) -> QualityRuleResult:
+    """Evaluate one data-quality rule against one target."""
+    return QualityRuleResult(
+        rule_id=rule.rule_id,
+        target=target,
+        findings=tuple(rule.evaluate(target)),
+    )
+
+
+def run_quality_assessment(
+    targets: Iterable[QualityTarget],
+    rules: Iterable[QualityRule],
+    *,
+    metadata: Mapping[str, JSONValue] | None = None,
+) -> QualityReport:
+    """Run every rule against every target through one orchestration path."""
+    target_tuple = tuple(targets)
+    rule_tuple = tuple(rules)
+    return QualityReport(
+        targets=target_tuple,
+        rule_results=tuple(
+            evaluate_quality_rule(rule, target)
+            for target in target_tuple
+            for rule in rule_tuple
+        ),
+        metadata=dict(metadata or {}),
+    )

--- a/src/histdatacom/data_quality/reporting.py
+++ b/src/histdatacom/data_quality/reporting.py
@@ -1,0 +1,279 @@
+"""Report serialization and exit policy helpers for data-quality runs."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import Enum
+import hashlib
+import json
+from pathlib import Path
+
+from histdatacom.data_quality.contracts import (
+    QualityReport,
+    QualityRunSummary,
+    QualityStatus,
+    QualityTargetSummary,
+)
+from histdatacom.runtime_contracts import ArtifactRef, JSONValue
+
+QUALITY_REPORT_SCHEMA_VERSION = "histdatacom.quality-report.v1"
+
+
+class QualityExitTrigger(str, Enum):
+    """Quality severities that can make a process exit non-zero."""
+
+    ERROR = "error"
+    WARNING = "warning"
+    NEVER = "never"
+
+    @classmethod
+    def from_value(
+        cls, value: str | "QualityExitTrigger" | None
+    ) -> "QualityExitTrigger":
+        """Normalize a public exit trigger value."""
+        if isinstance(value, cls):
+            return value
+        normalized = str(value or cls.ERROR.value).strip().lower()
+        aliases = {
+            "errors": cls.ERROR,
+            "warn": cls.WARNING,
+            "warnings": cls.WARNING,
+            "none": cls.NEVER,
+            "off": cls.NEVER,
+            "false": cls.NEVER,
+        }
+        if normalized in aliases:
+            return aliases[normalized]
+        try:
+            return cls(normalized)
+        except ValueError as exc:
+            msg = f"unknown quality exit trigger: {value!r}"
+            raise ValueError(msg) from exc
+
+
+QUALITY_EXIT_TRIGGERS = tuple(trigger.value for trigger in QualityExitTrigger)
+
+
+@dataclass(frozen=True, slots=True)
+class QualityExitPolicy:
+    """Configurable thresholds for quality-run process exit behavior."""
+
+    fail_on: QualityExitTrigger = QualityExitTrigger.ERROR
+    max_errors: int = 0
+    max_warnings: int = 0
+
+    @classmethod
+    def from_values(
+        cls,
+        *,
+        fail_on: str | QualityExitTrigger | None = None,
+        max_errors: int = 0,
+        max_warnings: int = 0,
+    ) -> "QualityExitPolicy":
+        """Create a validated exit policy from public values."""
+        if max_errors < 0:
+            msg = "quality max error threshold must be non-negative"
+            raise ValueError(msg)
+        if max_warnings < 0:
+            msg = "quality max warning threshold must be non-negative"
+            raise ValueError(msg)
+        return cls(
+            fail_on=QualityExitTrigger.from_value(fail_on),
+            max_errors=max_errors,
+            max_warnings=max_warnings,
+        )
+
+    def evaluate(self, summary: QualityRunSummary) -> "QualityExitDecision":
+        """Return the process-exit decision for a quality summary."""
+        if self.fail_on is QualityExitTrigger.NEVER:
+            return QualityExitDecision(
+                exit_code=0,
+                reason="quality exit policy is disabled",
+                policy=self,
+            )
+        if summary.error_count > self.max_errors:
+            return QualityExitDecision(
+                exit_code=1,
+                reason=(
+                    "quality error threshold exceeded: "
+                    f"{summary.error_count} > {self.max_errors}"
+                ),
+                policy=self,
+            )
+        if (
+            self.fail_on is QualityExitTrigger.WARNING
+            and summary.warning_count > self.max_warnings
+        ):
+            return QualityExitDecision(
+                exit_code=1,
+                reason=(
+                    "quality warning threshold exceeded: "
+                    f"{summary.warning_count} > {self.max_warnings}"
+                ),
+                policy=self,
+            )
+        return QualityExitDecision(
+            exit_code=0,
+            reason="quality report is within configured exit policy",
+            policy=self,
+        )
+
+    def to_dict(self) -> dict[str, JSONValue]:
+        """Return a JSON-compatible representation."""
+        return {
+            "fail_on": self.fail_on.value,
+            "max_errors": self.max_errors,
+            "max_warnings": self.max_warnings,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class QualityExitDecision:
+    """Result of applying a quality exit policy to a report summary."""
+
+    exit_code: int
+    reason: str
+    policy: QualityExitPolicy
+
+    def to_dict(self) -> dict[str, JSONValue]:
+        """Return a JSON-compatible representation."""
+        return {
+            "exit_code": self.exit_code,
+            "reason": self.reason,
+            "policy": self.policy.to_dict(),
+        }
+
+
+def quality_report_payload(report: QualityReport) -> dict[str, JSONValue]:
+    """Return the stable JSON report payload for a quality report."""
+    payload: dict[str, JSONValue] = dict(report.to_dict())
+    payload["schema_version"] = QUALITY_REPORT_SCHEMA_VERSION
+    return payload
+
+
+def quality_report_to_json(report: QualityReport) -> str:
+    """Return deterministic formatted JSON for a quality report."""
+    return json.dumps(
+        quality_report_payload(report),
+        indent=2,
+        sort_keys=True,
+    )
+
+
+def write_quality_report(
+    report: QualityReport,
+    path: str | Path,
+) -> ArtifactRef:
+    """Write a JSON quality report and return its artifact reference."""
+    output = Path(path).expanduser()
+    output.parent.mkdir(parents=True, exist_ok=True)
+    encoded = f"{quality_report_to_json(report)}\n".encode("utf-8")
+    output.write_bytes(encoded)
+    digest = hashlib.sha256(encoded).hexdigest()
+    summary = report.summary()
+    return ArtifactRef(
+        kind="quality-report",
+        path=str(output.resolve()),
+        size_bytes=len(encoded),
+        sha256=digest,
+        metadata={
+            "schema_version": QUALITY_REPORT_SCHEMA_VERSION,
+            "status": summary.status.value,
+            "max_severity": summary.max_severity.value,
+            "target_count": summary.target_count,
+            "finding_count": summary.finding_count,
+            "warning_count": summary.warning_count,
+            "error_count": summary.error_count,
+        },
+    )
+
+
+def format_quality_console_summary(
+    report: QualityReport,
+    *,
+    check_groups: tuple[str, ...] = (),
+    artifact: ArtifactRef | None = None,
+) -> str:
+    """Return a human-readable quality summary derived from the report."""
+    summary = report.summary()
+    lines = [
+        "Data quality assessment",
+        "checks: " + ", ".join(check_groups or ("all",)),
+        f"status: {summary.status.value}",
+        (
+            "targets: "
+            f"{summary.target_count} "
+            f"clean: {_target_count(report, QualityStatus.CLEAN)} "
+            f"warning: {_target_count(report, QualityStatus.WARNING)} "
+            f"failed: {_target_count(report, QualityStatus.FAILED)}"
+        ),
+        (
+            "findings: "
+            f"{summary.finding_count} "
+            f"info: {summary.info_count} "
+            f"warning: {summary.warning_count} "
+            f"error: {summary.error_count}"
+        ),
+    ]
+    if artifact is not None:
+        lines.append(f"report: {artifact.path}")
+    if summary.target_count == 0:
+        lines.append("No data quality targets discovered.")
+
+    sections = (
+        (QualityStatus.CLEAN, "Clean files"),
+        (QualityStatus.WARNING, "Warning files"),
+        (QualityStatus.FAILED, "Failed files"),
+    )
+    for status, title in sections:
+        lines.extend(("", title))
+        target_lines = tuple(
+            _format_target_summary(item)
+            for item in report.target_summaries
+            if item.status is status
+        )
+        if not target_lines:
+            lines.append("- none")
+        else:
+            lines.extend(target_lines)
+    return "\n".join(lines)
+
+
+def bounded_quality_payload(
+    *,
+    operation: str,
+    check_groups: tuple[str, ...],
+    discovery: Mapping[str, JSONValue],
+    report: QualityReport,
+    decision: QualityExitDecision,
+    artifact: ArtifactRef | None,
+) -> dict[str, JSONValue]:
+    """Return a bounded result payload without detailed findings."""
+    return {
+        "operation": operation,
+        "check_groups": list(check_groups),
+        "discovery": dict(discovery),
+        "summary": report.summary().to_dict(),
+        "target_summaries": [
+            summary.to_dict() for summary in report.target_summaries
+        ],
+        "report_schema_version": QUALITY_REPORT_SCHEMA_VERSION,
+        "report_artifact": None if artifact is None else artifact.to_dict(),
+        "exit_decision": decision.to_dict(),
+    }
+
+
+def _target_count(report: QualityReport, status: QualityStatus) -> int:
+    return sum(
+        1 for summary in report.target_summaries if summary.status is status
+    )
+
+
+def _format_target_summary(summary: QualityTargetSummary) -> str:
+    target = summary.target
+    return (
+        f"- {target.kind.value}: {target.path} "
+        f"(findings={summary.finding_count}, "
+        f"warnings={summary.warning_count}, errors={summary.error_count})"
+    )

--- a/src/histdatacom/histdata_com.py
+++ b/src/histdatacom/histdata_com.py
@@ -33,6 +33,12 @@ from typing import TYPE_CHECKING, Any, Mapping
 import histdatacom
 from histdatacom import Options
 from histdatacom.cli import ArgParser
+from histdatacom.data_quality import (
+    QualityDiscoveryError,
+    discover_quality_targets,
+    normalize_quality_check_groups,
+    run_quality_assessment,
+)
 from histdatacom.exceptions import InfluxConfigurationError
 from histdatacom.repository_output import (
     print_repository_failure,
@@ -72,6 +78,9 @@ class RuntimeContext:
     sidecar_start: bool
     sidecar_wait_result: bool
     api_return_type: str | None
+    data_quality: bool
+    quality_paths: tuple[str, ...]
+    quality_check_groups: tuple[str, ...]
     available_remote_data: bool
     update_remote_data: bool
     import_to_influxdb: bool
@@ -130,7 +139,41 @@ class _HistDataCom:  # noqa:R701
                 print(histdatacom.__version__)  # noqa:T201
             return histdatacom.__version__
 
+        if self.context.data_quality:
+            return self._run_data_quality()
+
         return self._run_sidecar_job()
+
+    def _run_data_quality(self) -> dict:
+        """Run local-only data-quality target discovery."""
+        try:
+            check_groups = normalize_quality_check_groups(
+                self.context.quality_check_groups
+            )
+            discovery = discover_quality_targets(self.context.quality_paths)
+        except QualityDiscoveryError as err:
+            if self.context.from_api:
+                raise
+            print(f"error: {err}", file=sys.stderr)  # noqa:T201
+            raise SystemExit(1) from err
+
+        report = run_quality_assessment(
+            discovery.targets,
+            (),
+            metadata={
+                "operation": "data-quality",
+                "check_groups": list(check_groups),
+            },
+        )
+        payload = {
+            "operation": "data-quality",
+            "check_groups": list(check_groups),
+            "discovery": discovery.to_dict(),
+            "summary": report.summary().to_dict(),
+        }
+        if not self.context.from_api:
+            _print_data_quality_discovery(payload)
+        return payload
 
     def _run_sidecar_job(
         self,
@@ -245,6 +288,15 @@ def _resolve_runtime_context(options: Options) -> RuntimeContext:
         sidecar_start=bool(args["sidecar_start"]),
         sidecar_wait_result=bool(args["sidecar_wait_result"]),
         api_return_type=args["api_return_type"],
+        data_quality=bool(args["data_quality"]),
+        quality_paths=tuple(
+            str(path) for path in (args.get("quality_paths") or ())
+        ),
+        quality_check_groups=tuple(
+            sorted(
+                str(group) for group in (args.get("quality_check_groups") or ())
+            )
+        ),
         available_remote_data=bool(args["available_remote_data"]),
         update_remote_data=bool(args["update_remote_data"]),
         import_to_influxdb=bool(args["import_to_influxdb"]),
@@ -312,6 +364,32 @@ def _freeze_runtime_arg(value: Any) -> Any:
             {key: _freeze_runtime_arg(item) for key, item in value.items()}
         )
     return value
+
+
+def _print_data_quality_discovery(payload: Mapping[str, Any]) -> None:
+    """Print a compact local target discovery summary."""
+    discovery = payload.get("discovery", {})
+    if not isinstance(discovery, Mapping):
+        discovery = {}
+    targets = discovery.get("targets", [])
+    if not isinstance(targets, list):
+        targets = []
+
+    print("Data quality target discovery")  # noqa:T201
+    print(  # noqa:T201
+        "checks: " + ", ".join(str(item) for item in payload["check_groups"])
+    )
+    print(f"roots: {len(discovery.get('roots', []))}")  # noqa:T201
+    print(f"targets: {len(targets)}")  # noqa:T201
+    if not targets:
+        print("No data quality targets discovered.")  # noqa:T201
+        return
+    for target in targets:
+        if not isinstance(target, Mapping):
+            continue
+        print(  # noqa:T201
+            f"- {target.get('kind', 'unknown')}: {target.get('path', '')}"
+        )
 
 
 def main(

--- a/src/histdatacom/histdata_com.py
+++ b/src/histdatacom/histdata_com.py
@@ -33,6 +33,7 @@ from typing import TYPE_CHECKING, Any, Mapping
 import histdatacom
 from histdatacom import Options
 from histdatacom.cli import ArgParser
+from histdatacom.exceptions import InfluxConfigurationError
 from histdatacom.repository_output import (
     print_repository_failure,
     print_repository_table,
@@ -49,6 +50,7 @@ from histdatacom.sidecar.cutover import (
     should_submit_to_sidecar,
 )
 from histdatacom.utils import (
+    load_influx_yaml,
     set_working_data_dir,
     normalize_api_return_type,
 )
@@ -226,6 +228,7 @@ def _resolve_runtime_context(options: Options) -> RuntimeContext:
     args["default_download_dir"] = set_working_data_dir(args["data_directory"])
     args["api_return_type"] = normalize_api_return_type(args["api_return_type"])
     options.api_return_type = args["api_return_type"]
+    _attach_influx_config_metadata(options, args)
     try:
         should_submit_to_sidecar(args)
     except ValueError as err:
@@ -246,6 +249,56 @@ def _resolve_runtime_context(options: Options) -> RuntimeContext:
         update_remote_data=bool(args["update_remote_data"]),
         import_to_influxdb=bool(args["import_to_influxdb"]),
     )
+
+
+def _attach_influx_config_metadata(
+    options: Options,
+    args: dict[str, Any],
+) -> None:
+    """Snapshot caller-local Influx config before sidecar handoff."""
+    if not bool(args.get("import_to_influxdb")):
+        return
+    metadata = dict(getattr(options, "metadata", {}) or {})
+    if isinstance(metadata.get("influx_config"), Mapping):
+        _validate_influx_metadata_config(metadata["influx_config"])
+        options.metadata = metadata
+        args["metadata"] = metadata
+        return
+    influx_yaml = load_influx_yaml()
+    influx_config = dict(influx_yaml.get("influxdb") or {})
+    missing = [
+        key
+        for key in ("org", "bucket", "url", "token")
+        if not influx_config.get(key)
+    ]
+    if missing:
+        missing_text = ", ".join(missing)
+        raise InfluxConfigurationError(
+            "influxdb.yaml is missing required influxdb keys: "
+            f"{missing_text}."
+        )
+    metadata["influx_config"] = {
+        "INFLUX_ORG": str(influx_config.get("org", "") or ""),
+        "INFLUX_BUCKET": str(influx_config.get("bucket", "") or ""),
+        "INFLUX_URL": str(influx_config.get("url", "") or ""),
+        "INFLUX_TOKEN": str(influx_config.get("token", "") or ""),
+    }
+    options.metadata = metadata
+    args["metadata"] = metadata
+
+
+def _validate_influx_metadata_config(config: Mapping[str, Any]) -> None:
+    """Validate serialized sidecar Influx connection keys."""
+    missing = [
+        key
+        for key in ("INFLUX_ORG", "INFLUX_BUCKET", "INFLUX_URL", "INFLUX_TOKEN")
+        if not config.get(key)
+    ]
+    if missing:
+        missing_text = ", ".join(missing)
+        raise InfluxConfigurationError(
+            "influx metadata is missing required keys: " f"{missing_text}."
+        )
 
 
 def _freeze_runtime_arg(value: Any) -> Any:

--- a/src/histdatacom/histdata_com.py
+++ b/src/histdatacom/histdata_com.py
@@ -35,9 +35,13 @@ from histdatacom import Options
 from histdatacom.cli import ArgParser
 from histdatacom.data_quality import (
     QualityDiscoveryError,
+    QualityExitPolicy,
+    bounded_quality_payload,
     discover_quality_targets,
+    format_quality_console_summary,
     normalize_quality_check_groups,
     run_quality_assessment,
+    write_quality_report,
 )
 from histdatacom.exceptions import InfluxConfigurationError
 from histdatacom.repository_output import (
@@ -81,6 +85,10 @@ class RuntimeContext:
     data_quality: bool
     quality_paths: tuple[str, ...]
     quality_check_groups: tuple[str, ...]
+    quality_report_path: str | None
+    quality_fail_on: str
+    quality_max_errors: int
+    quality_max_warnings: int
     available_remote_data: bool
     update_remote_data: bool
     import_to_influxdb: bool
@@ -145,13 +153,23 @@ class _HistDataCom:  # noqa:R701
         return self._run_sidecar_job()
 
     def _run_data_quality(self) -> dict:
-        """Run local-only data-quality target discovery."""
+        """Run a local-only data-quality assessment."""
         try:
             check_groups = normalize_quality_check_groups(
                 self.context.quality_check_groups
             )
             discovery = discover_quality_targets(self.context.quality_paths)
+            exit_policy = QualityExitPolicy.from_values(
+                fail_on=self.context.quality_fail_on,
+                max_errors=self.context.quality_max_errors,
+                max_warnings=self.context.quality_max_warnings,
+            )
         except QualityDiscoveryError as err:
+            if self.context.from_api:
+                raise
+            print(f"error: {err}", file=sys.stderr)  # noqa:T201
+            raise SystemExit(1) from err
+        except ValueError as err:
             if self.context.from_api:
                 raise
             print(f"error: {err}", file=sys.stderr)  # noqa:T201
@@ -165,14 +183,30 @@ class _HistDataCom:  # noqa:R701
                 "check_groups": list(check_groups),
             },
         )
-        payload = {
-            "operation": "data-quality",
-            "check_groups": list(check_groups),
-            "discovery": discovery.to_dict(),
-            "summary": report.summary().to_dict(),
-        }
+        artifact = (
+            None
+            if self.context.quality_report_path is None
+            else write_quality_report(report, self.context.quality_report_path)
+        )
+        decision = exit_policy.evaluate(report.summary())
+        payload = bounded_quality_payload(
+            operation="data-quality",
+            check_groups=check_groups,
+            discovery=discovery.to_dict(),
+            report=report,
+            decision=decision,
+            artifact=artifact,
+        )
         if not self.context.from_api:
-            _print_data_quality_discovery(payload)
+            print(  # noqa:T201
+                format_quality_console_summary(
+                    report,
+                    check_groups=check_groups,
+                    artifact=artifact,
+                )
+            )
+            if decision.exit_code:
+                raise SystemExit(decision.exit_code)
         return payload
 
     def _run_sidecar_job(
@@ -297,6 +331,14 @@ def _resolve_runtime_context(options: Options) -> RuntimeContext:
                 str(group) for group in (args.get("quality_check_groups") or ())
             )
         ),
+        quality_report_path=(
+            None
+            if args.get("quality_report_path") is None
+            else str(args["quality_report_path"])
+        ),
+        quality_fail_on=str(args["quality_fail_on"]),
+        quality_max_errors=int(args["quality_max_errors"]),
+        quality_max_warnings=int(args["quality_max_warnings"]),
         available_remote_data=bool(args["available_remote_data"]),
         update_remote_data=bool(args["update_remote_data"]),
         import_to_influxdb=bool(args["import_to_influxdb"]),
@@ -364,32 +406,6 @@ def _freeze_runtime_arg(value: Any) -> Any:
             {key: _freeze_runtime_arg(item) for key, item in value.items()}
         )
     return value
-
-
-def _print_data_quality_discovery(payload: Mapping[str, Any]) -> None:
-    """Print a compact local target discovery summary."""
-    discovery = payload.get("discovery", {})
-    if not isinstance(discovery, Mapping):
-        discovery = {}
-    targets = discovery.get("targets", [])
-    if not isinstance(targets, list):
-        targets = []
-
-    print("Data quality target discovery")  # noqa:T201
-    print(  # noqa:T201
-        "checks: " + ", ".join(str(item) for item in payload["check_groups"])
-    )
-    print(f"roots: {len(discovery.get('roots', []))}")  # noqa:T201
-    print(f"targets: {len(targets)}")  # noqa:T201
-    if not targets:
-        print("No data quality targets discovered.")  # noqa:T201
-        return
-    for target in targets:
-        if not isinstance(target, Mapping):
-            continue
-        print(  # noqa:T201
-            f"- {target.get('kind', 'unknown')}: {target.get('path', '')}"
-        )
 
 
 def main(

--- a/src/histdatacom/options.py
+++ b/src/histdatacom/options.py
@@ -35,6 +35,9 @@ class Options:
         self.batch_size: str = "5000"
         self.delete_after_influx: bool = False
         self.zip_persist: bool = False
+        self.data_quality: bool = False
+        self.quality_paths: tuple[str, ...] = ()
+        self.quality_check_groups: set[str] = {"all"}
         self.use_sidecar: bool = True
         self.sidecar_start: bool = True
         self.sidecar_wait_result: bool = True

--- a/src/histdatacom/options.py
+++ b/src/histdatacom/options.py
@@ -38,6 +38,10 @@ class Options:
         self.data_quality: bool = False
         self.quality_paths: tuple[str, ...] = ()
         self.quality_check_groups: set[str] = {"all"}
+        self.quality_report_path: str | None = None
+        self.quality_fail_on: str = "error"
+        self.quality_max_errors: int = 0
+        self.quality_max_warnings: int = 0
         self.use_sidecar: bool = True
         self.sidecar_start: bool = True
         self.sidecar_wait_result: bool = True

--- a/src/histdatacom/options.py
+++ b/src/histdatacom/options.py
@@ -38,3 +38,4 @@ class Options:
         self.use_sidecar: bool = True
         self.sidecar_start: bool = True
         self.sidecar_wait_result: bool = True
+        self.metadata: dict = {}

--- a/src/histdatacom/sidecar/activities.py
+++ b/src/histdatacom/sidecar/activities.py
@@ -553,11 +553,25 @@ def _repo_local_path(request: RunRequest) -> Path:
 
 
 def _influx_args(request: RunRequest) -> dict[str, Any]:
-    return {
+    args = {
         "default_download_dir": set_working_data_dir(request.data_directory),
         "batch_size": request.batch_size,
         "delete_after_influx": request.delete_after_influx,
     }
+    influx_config = request.metadata.get("influx_config")
+    if isinstance(influx_config, Mapping):
+        args.update(
+            {
+                key: str(influx_config.get(key, "") or "")
+                for key in (
+                    "INFLUX_ORG",
+                    "INFLUX_BUCKET",
+                    "INFLUX_URL",
+                    "INFLUX_TOKEN",
+                )
+            }
+        )
+    return args
 
 
 def _influx_batch_writer(args: Mapping[str, Any]) -> Any:

--- a/src/histdatacom/sidecar/cli.py
+++ b/src/histdatacom/sidecar/cli.py
@@ -200,6 +200,7 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="return after submission instead of waiting for the result",
     )
+    _add_job_command_common_args(submit, include_offline=False)
 
     list_jobs = job_subparsers.add_parser(
         "list",
@@ -216,6 +217,7 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         help="maximum stored jobs to return in offline/fallback mode",
     )
+    _add_job_command_common_args(list_jobs, include_offline=True)
 
     for command, help_text in (
         ("inspect", "inspect one sidecar job"),
@@ -229,6 +231,7 @@ def build_parser() -> argparse.ArgumentParser:
     ):
         job_parser = job_subparsers.add_parser(command, help=help_text)
         _add_job_identity_args(job_parser)
+        _add_job_command_common_args(job_parser, include_offline=True)
         if command in {"cancel", "retry", "resume"}:
             job_parser.add_argument(
                 "--reason",
@@ -364,6 +367,27 @@ def _add_job_identity_args(parser: argparse.ArgumentParser) -> None:
         default="",
         help="Temporal run ID when targeting a specific run",
     )
+
+
+def _add_job_command_common_args(
+    parser: argparse.ArgumentParser,
+    *,
+    include_offline: bool,
+) -> None:
+    """Accept shared jobs options after a job subcommand."""
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        default=argparse.SUPPRESS,
+        help="emit machine-readable JSON",
+    )
+    if include_offline:
+        parser.add_argument(
+            "--offline",
+            action="store_true",
+            default=argparse.SUPPRESS,
+            help="read persisted local job snapshots without querying Temporal",
+        )
 
 
 def _add_maintenance_args(parser: argparse.ArgumentParser) -> None:

--- a/tests/fixtures/histdata_ascii/quality_cases.py
+++ b/tests/fixtures/histdata_ascii/quality_cases.py
@@ -1,0 +1,342 @@
+"""Reusable HistData ASCII fixture cases for data-quality rule tests."""
+
+from __future__ import annotations
+
+import shutil
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+from histdatacom.histdata_ascii import M1, TICK
+
+FIXTURE_ROOT = Path(__file__).resolve().parent
+CLEAN_M1_FIXTURE = FIXTURE_ROOT / "DAT_ASCII_EURUSD_M1_201202.csv"
+CLEAN_TICK_FIXTURE = FIXTURE_ROOT / "DAT_ASCII_EURUSD_T_201202.csv"
+
+
+@dataclass(frozen=True, slots=True)
+class HistDataAsciiCase:
+    """One clean or intentionally dirty HistData ASCII fixture case."""
+
+    name: str
+    timeframe: str
+    filename: str
+    rows: tuple[str, ...] = ()
+    anomalies: tuple[str, ...] = ()
+    missing: bool = False
+
+    @property
+    def text(self) -> str:
+        """Return the newline-terminated CSV payload for this case."""
+        if not self.rows:
+            return ""
+        return "\n".join(self.rows) + "\n"
+
+    @property
+    def clean(self) -> bool:
+        """Return whether this case is intended to parse without findings."""
+        return not self.anomalies and not self.missing
+
+
+@dataclass(frozen=True, slots=True)
+class EstNoDstTimestampCase:
+    """One source timestamp with its fixed EST-no-DST UTC millisecond value."""
+
+    timeframe: str
+    raw: str
+    expected_utc_ms: int
+    description: str
+
+
+CLEAN_M1_ROWS = (
+    "20120201 000000;1.306600;1.306600;1.306560;1.306560;0",
+    "20120201 000100;1.306570;1.306570;1.306470;1.306560;17",
+    "20120201 000200;1.306520;1.306560;1.306520;1.306560;2147483647",
+)
+CLEAN_TICK_ROWS = (
+    "20120201 000003660,1.306600,1.306770,0",
+    "20120201 000003973,1.306580,1.306750,25",
+    "20120201 000014990,1.306570,1.306740,2147483647",
+)
+
+CLEAN_M1_CASE = HistDataAsciiCase(
+    name="clean_m1",
+    timeframe=M1,
+    filename="DAT_ASCII_EURUSD_M1_201202.csv",
+    rows=CLEAN_M1_ROWS,
+)
+CLEAN_TICK_CASE = HistDataAsciiCase(
+    name="clean_tick",
+    timeframe=TICK,
+    filename="DAT_ASCII_EURUSD_T_201202.csv",
+    rows=CLEAN_TICK_ROWS,
+)
+
+DIRTY_M1_CASES = (
+    HistDataAsciiCase(
+        name="m1_malformed_row",
+        timeframe=M1,
+        filename="DAT_ASCII_EURUSD_M1_201202_MALFORMED.csv",
+        rows=(
+            CLEAN_M1_ROWS[0],
+            "20120201 000100;1.306570;1.306570",
+        ),
+        anomalies=("malformed_row",),
+    ),
+    HistDataAsciiCase(
+        name="m1_bad_timestamp",
+        timeframe=M1,
+        filename="DAT_ASCII_EURUSD_M1_201202_BAD_TIMESTAMP.csv",
+        rows=(
+            CLEAN_M1_ROWS[0],
+            "20120230 000000;1.306570;1.306570;1.306470;1.306560;17",
+        ),
+        anomalies=("bad_timestamp",),
+    ),
+    HistDataAsciiCase(
+        name="m1_duplicate_timestamp",
+        timeframe=M1,
+        filename="DAT_ASCII_EURUSD_M1_201202_DUPLICATE.csv",
+        rows=(
+            CLEAN_M1_ROWS[0],
+            "20120201 000000;1.306570;1.306570;1.306470;1.306560;17",
+            CLEAN_M1_ROWS[2],
+        ),
+        anomalies=("duplicate_timestamp",),
+    ),
+    HistDataAsciiCase(
+        name="m1_non_monotonic_timestamp",
+        timeframe=M1,
+        filename="DAT_ASCII_EURUSD_M1_201202_NON_MONOTONIC.csv",
+        rows=(
+            CLEAN_M1_ROWS[1],
+            CLEAN_M1_ROWS[0],
+            CLEAN_M1_ROWS[2],
+        ),
+        anomalies=("non_monotonic_timestamp",),
+    ),
+    HistDataAsciiCase(
+        name="m1_ohlc_violation",
+        timeframe=M1,
+        filename="DAT_ASCII_EURUSD_M1_201202_BAD_OHLC.csv",
+        rows=(
+            CLEAN_M1_ROWS[0],
+            "20120201 000100;1.306570;1.306500;1.306470;1.306560;17",
+        ),
+        anomalies=("ohlc_violation",),
+    ),
+    HistDataAsciiCase(
+        name="m1_header_row",
+        timeframe=M1,
+        filename="DAT_ASCII_EURUSD_M1_201202_HEADER.csv",
+        rows=(
+            "datetime;open;high;low;close;vol",
+            CLEAN_M1_ROWS[0],
+        ),
+        anomalies=("header_row", "bad_timestamp"),
+    ),
+    HistDataAsciiCase(
+        name="m1_bad_delimiter",
+        timeframe=M1,
+        filename="DAT_ASCII_EURUSD_M1_201202_BAD_DELIMITER.csv",
+        rows=("20120201 000000,1.306600,1.306600,1.306560,1.306560,0",),
+        anomalies=("bad_delimiter", "malformed_row"),
+    ),
+    HistDataAsciiCase(
+        name="m1_empty_file",
+        timeframe=M1,
+        filename="DAT_ASCII_EURUSD_M1_201202_EMPTY.csv",
+        anomalies=("empty_file",),
+    ),
+    HistDataAsciiCase(
+        name="m1_missing_file",
+        timeframe=M1,
+        filename="DAT_ASCII_EURUSD_M1_201202_MISSING.csv",
+        anomalies=("missing_file",),
+        missing=True,
+    ),
+)
+
+DIRTY_TICK_CASES = (
+    HistDataAsciiCase(
+        name="tick_malformed_row",
+        timeframe=TICK,
+        filename="DAT_ASCII_EURUSD_T_201202_MALFORMED.csv",
+        rows=(
+            CLEAN_TICK_ROWS[0],
+            "20120201 000003973,1.306580,1.306750",
+        ),
+        anomalies=("malformed_row",),
+    ),
+    HistDataAsciiCase(
+        name="tick_bad_timestamp",
+        timeframe=TICK,
+        filename="DAT_ASCII_EURUSD_T_201202_BAD_TIMESTAMP.csv",
+        rows=(
+            CLEAN_TICK_ROWS[0],
+            "20120230 000003973,1.306580,1.306750,25",
+        ),
+        anomalies=("bad_timestamp",),
+    ),
+    HistDataAsciiCase(
+        name="tick_duplicate_row",
+        timeframe=TICK,
+        filename="DAT_ASCII_EURUSD_T_201202_DUPLICATE.csv",
+        rows=(
+            CLEAN_TICK_ROWS[0],
+            CLEAN_TICK_ROWS[0],
+            CLEAN_TICK_ROWS[2],
+        ),
+        anomalies=("duplicate_tick", "duplicate_timestamp"),
+    ),
+    HistDataAsciiCase(
+        name="tick_non_monotonic_timestamp",
+        timeframe=TICK,
+        filename="DAT_ASCII_EURUSD_T_201202_NON_MONOTONIC.csv",
+        rows=(
+            CLEAN_TICK_ROWS[1],
+            CLEAN_TICK_ROWS[0],
+            CLEAN_TICK_ROWS[2],
+        ),
+        anomalies=("non_monotonic_timestamp",),
+    ),
+    HistDataAsciiCase(
+        name="tick_negative_spread",
+        timeframe=TICK,
+        filename="DAT_ASCII_EURUSD_T_201202_NEGATIVE_SPREAD.csv",
+        rows=(
+            CLEAN_TICK_ROWS[0],
+            "20120201 000003973,1.306800,1.306750,25",
+        ),
+        anomalies=("negative_spread",),
+    ),
+    HistDataAsciiCase(
+        name="tick_header_row",
+        timeframe=TICK,
+        filename="DAT_ASCII_EURUSD_T_201202_HEADER.csv",
+        rows=(
+            "datetime,bid,ask,vol",
+            CLEAN_TICK_ROWS[0],
+        ),
+        anomalies=("header_row", "bad_timestamp"),
+    ),
+    HistDataAsciiCase(
+        name="tick_bad_delimiter",
+        timeframe=TICK,
+        filename="DAT_ASCII_EURUSD_T_201202_BAD_DELIMITER.csv",
+        rows=("20120201 000003660;1.306600;1.306770;0",),
+        anomalies=("bad_delimiter", "malformed_row"),
+    ),
+    HistDataAsciiCase(
+        name="tick_empty_file",
+        timeframe=TICK,
+        filename="DAT_ASCII_EURUSD_T_201202_EMPTY.csv",
+        anomalies=("empty_file",),
+    ),
+    HistDataAsciiCase(
+        name="tick_missing_file",
+        timeframe=TICK,
+        filename="DAT_ASCII_EURUSD_T_201202_MISSING.csv",
+        anomalies=("missing_file",),
+        missing=True,
+    ),
+)
+
+ALL_CLEAN_CASES = (CLEAN_M1_CASE, CLEAN_TICK_CASE)
+ALL_DIRTY_CASES = (*DIRTY_M1_CASES, *DIRTY_TICK_CASES)
+ALL_ASCII_CASES = (*ALL_CLEAN_CASES, *ALL_DIRTY_CASES)
+
+EST_NO_DST_CALENDAR_CASES = (
+    EstNoDstTimestampCase(
+        timeframe=M1,
+        raw="20120229 235900",
+        expected_utc_ms=1330577940000,
+        description="leap-day minute bar",
+    ),
+    EstNoDstTimestampCase(
+        timeframe=M1,
+        raw="20220313 023000",
+        expected_utc_ms=1647156600000,
+        description="US spring DST transition treated as fixed EST",
+    ),
+    EstNoDstTimestampCase(
+        timeframe=M1,
+        raw="20221106 013000",
+        expected_utc_ms=1667716200000,
+        description="US fall DST transition treated as fixed EST",
+    ),
+    EstNoDstTimestampCase(
+        timeframe=TICK,
+        raw="20120229 235959999",
+        expected_utc_ms=1330577999999,
+        description="leap-day tick with millisecond precision",
+    ),
+    EstNoDstTimestampCase(
+        timeframe=TICK,
+        raw="20170101 000000000",
+        expected_utc_ms=1483246800000,
+        description="year boundary tick",
+    ),
+)
+
+
+def case_by_name(name: str) -> HistDataAsciiCase:
+    """Return a fixture case by its stable case name."""
+    for case in ALL_ASCII_CASES:
+        if case.name == name:
+            return case
+    raise KeyError(name)
+
+
+def write_ascii_case(directory: Path, case: HistDataAsciiCase) -> Path:
+    """Write one fixture case as a CSV file and return its target path."""
+    target = directory / case.filename
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if case.missing:
+        if target.exists():
+            target.unlink()
+        return target
+    target.write_text(case.text, encoding="utf-8")
+    return target
+
+
+def copy_clean_fixture(directory: Path, timeframe: str) -> Path:
+    """Copy the static clean fixture for a supported timeframe."""
+    source = {
+        M1: CLEAN_M1_FIXTURE,
+        TICK: CLEAN_TICK_FIXTURE,
+    }[timeframe]
+    target = directory / source.name
+    target.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(source, target)
+    return target
+
+
+def write_zip_case(
+    directory: Path,
+    case: HistDataAsciiCase,
+    *,
+    zip_filename: str | None = None,
+    extra_members: Iterable[tuple[str, str | bytes]] = (),
+) -> Path:
+    """Write a ZIP archive for one fixture case."""
+    target = directory / (zip_filename or f"{case.filename}.zip")
+    target.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(target, "w") as archive:
+        if not case.missing:
+            archive.writestr(case.filename, case.text)
+        for member_name, content in extra_members:
+            archive.writestr(member_name, content)
+    return target
+
+
+def write_corrupt_zip(
+    directory: Path,
+    filename: str = "DAT_ASCII_EURUSD_M1_201202_CORRUPT.zip",
+) -> Path:
+    """Write bytes that should fail ZIP integrity checks."""
+    target = directory / filename
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_bytes(b"not a zip archive")
+    return target

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -254,6 +254,7 @@ def test_argparser_bare_construction_uses_fresh_option_namespace(
     assert first_options.data_directory == str(first_data_dir)
     assert first_options.validate_urls
     assert first_options.download_data_archives
+    assert first_options.extract_csvs
     assert first_options.import_to_influxdb
     assert first_options.delete_after_influx
     assert not first_options.sidecar_start
@@ -337,7 +338,7 @@ def test_argparser_bare_construction_uses_fresh_option_namespace(
                 "update_remote_data": False,
                 "validate_urls": True,
                 "download_data_archives": True,
-                "extract_csvs": False,
+                "extract_csvs": True,
                 "import_to_influxdb": True,
             },
         ),

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -174,6 +174,80 @@ def test_no_sidecar_start_cli_flag_requires_running_sidecar(
     assert options.validate_urls
 
 
+def test_data_quality_cli_mode_bypasses_legacy_prerequisites(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Offline quality mode should not auto-enable network/download stages."""
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "histdatacom",
+            "--quality",
+            "--quality-target",
+            str(tmp_path),
+            "--quality-checks",
+            "inventory",
+            "ingestion",
+        ],
+    )
+
+    options = ArgParser(Options())()
+
+    assert options.data_quality
+    assert options.quality_paths == [str(tmp_path)]
+    assert options.quality_check_groups == ["inventory", "ingestion"]
+    assert not options.validate_urls
+    assert not options.download_data_archives
+    assert not options.extract_csvs
+    assert not options.import_to_influxdb
+
+
+def test_data_quality_cli_defaults_to_data_directory(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Operators can run quality mode against the configured data directory."""
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "histdatacom",
+            "--quality",
+            "--data-directory",
+            str(tmp_path),
+        ],
+    )
+
+    options = ArgParser(Options())()
+
+    assert options.data_quality
+    assert options.quality_paths == (str(tmp_path),)
+    assert not options.validate_urls
+
+
+@pytest.mark.parametrize(
+    "argv",
+    (
+        ["histdatacom", "--quality-target", "data"],
+        ["histdatacom", "--quality-checks", "inventory"],
+        ["histdatacom", "--quality", "-D"],
+    ),
+)
+def test_data_quality_cli_rejects_ambiguous_quality_flags(
+    argv: list[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Quality mode should stay separate from legacy network operations."""
+    monkeypatch.setattr(sys, "argv", argv)
+
+    with pytest.raises(SystemExit) as err:
+        ArgParser(Options())()
+
+    assert err.value.code == 1
+
+
 def test_api_options_ignore_ambient_process_argv(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -190,6 +190,14 @@ def test_data_quality_cli_mode_bypasses_legacy_prerequisites(
             "--quality-checks",
             "inventory",
             "ingestion",
+            "--quality-report",
+            str(tmp_path / "quality.json"),
+            "--quality-fail-on",
+            "warning",
+            "--quality-max-errors",
+            "2",
+            "--quality-max-warnings",
+            "5",
         ],
     )
 
@@ -198,6 +206,10 @@ def test_data_quality_cli_mode_bypasses_legacy_prerequisites(
     assert options.data_quality
     assert options.quality_paths == [str(tmp_path)]
     assert options.quality_check_groups == ["inventory", "ingestion"]
+    assert options.quality_report_path == str(tmp_path / "quality.json")
+    assert options.quality_fail_on == "warning"
+    assert options.quality_max_errors == 2
+    assert options.quality_max_warnings == 5
     assert not options.validate_urls
     assert not options.download_data_archives
     assert not options.extract_csvs
@@ -232,6 +244,10 @@ def test_data_quality_cli_defaults_to_data_directory(
     (
         ["histdatacom", "--quality-target", "data"],
         ["histdatacom", "--quality-checks", "inventory"],
+        ["histdatacom", "--quality-report", "quality.json"],
+        ["histdatacom", "--quality-fail-on", "warning"],
+        ["histdatacom", "--quality-max-errors", "1"],
+        ["histdatacom", "--quality-max-warnings", "1"],
         ["histdatacom", "--quality", "-D"],
     ),
 )

--- a/tests/unit/test_data_quality_discovery.py
+++ b/tests/unit/test_data_quality_discovery.py
@@ -1,0 +1,133 @@
+"""Tests for offline data-quality target discovery."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from histdatacom.data_quality import (
+    QualityDiscoveryError,
+    QualityDiscoveryResult,
+    QualityTargetKind,
+    discover_quality_targets,
+    normalize_quality_check_groups,
+    quality_target_from_path,
+)
+from histdatacom.histdata_ascii import CACHE_FILENAME, M1
+from tests.fixtures.histdata_ascii.quality_cases import (
+    CLEAN_M1_CASE,
+    write_ascii_case,
+    write_zip_case,
+)
+
+
+def test_quality_discovery_recursively_finds_zip_csv_and_cache_targets(
+    tmp_path: Path,
+) -> None:
+    """Directory discovery should find supported local targets recursively."""
+    nested = tmp_path / "nested"
+    csv_path = write_ascii_case(nested, CLEAN_M1_CASE)
+    zip_path = write_zip_case(
+        tmp_path,
+        CLEAN_M1_CASE,
+        zip_filename="DAT_ASCII_EURUSD_M1_201202.zip",
+    )
+    cache_path = nested / CACHE_FILENAME
+    cache_path.write_bytes(b"placeholder cache bytes")
+    (nested / "README.txt").write_text("not a target", encoding="utf-8")
+
+    result = discover_quality_targets((tmp_path,))
+
+    assert result.roots == (str(tmp_path),)
+    assert result.target_count == 3
+    assert {
+        (Path(target.path).name, target.kind) for target in result.targets
+    } == {
+        (csv_path.name, QualityTargetKind.CSV),
+        (zip_path.name, QualityTargetKind.ZIP),
+        (cache_path.name, QualityTargetKind.CACHE),
+    }
+    csv_target = next(
+        target
+        for target in result.targets
+        if target.kind == QualityTargetKind.CSV
+    )
+    zip_target = next(
+        target
+        for target in result.targets
+        if target.kind == QualityTargetKind.ZIP
+    )
+    assert csv_target.data_format == "ascii"
+    assert csv_target.symbol == "EURUSD"
+    assert csv_target.timeframe == M1
+    assert csv_target.period == "201202"
+    assert zip_target.data_format == "ascii"
+    assert zip_target.symbol == "EURUSD"
+    assert zip_target.timeframe == M1
+    assert zip_target.period == "201202"
+    assert (
+        QualityDiscoveryResult.from_dict(result.to_dict()).to_dict()
+        == result.to_dict()
+    )
+
+
+@pytest.mark.parametrize(
+    ("filename", "kind"),
+    (
+        ("DAT_ASCII_EURUSD_M1_201202.csv", QualityTargetKind.CSV),
+        ("DAT_ASCII_EURUSD_M1_201202.zip", QualityTargetKind.ZIP),
+        (CACHE_FILENAME, QualityTargetKind.CACHE),
+    ),
+)
+def test_quality_target_from_path_classifies_supported_files(
+    tmp_path: Path,
+    filename: str,
+    kind: QualityTargetKind,
+) -> None:
+    """Supported files should map to QualityTarget objects."""
+    path = tmp_path / filename
+    path.write_bytes(b"")
+
+    target = quality_target_from_path(path)
+
+    assert target is not None
+    assert target.kind == kind
+    assert target.path == str(path.resolve())
+
+
+def test_quality_discovery_rejects_missing_and_unsupported_paths(
+    tmp_path: Path,
+) -> None:
+    """Operators should get clear setup errors for invalid roots."""
+    with pytest.raises(QualityDiscoveryError, match="does not exist"):
+        discover_quality_targets((tmp_path / "missing",))
+
+    unsupported = tmp_path / "notes.txt"
+    unsupported.write_text("not a quality target", encoding="utf-8")
+    with pytest.raises(QualityDiscoveryError, match="unsupported"):
+        discover_quality_targets((unsupported,))
+
+
+def test_quality_discovery_allows_empty_directories(tmp_path: Path) -> None:
+    """An empty local directory should produce an empty discovery result."""
+    result = discover_quality_targets((tmp_path,))
+
+    assert result.target_count == 0
+    assert result.targets == ()
+
+
+def test_quality_check_groups_normalize_and_validate_operator_selection() -> (
+    None
+):
+    """CLI/API check group selections should be deterministic."""
+    assert normalize_quality_check_groups(None) == ("all",)
+    assert normalize_quality_check_groups(("inventory", "time", "time")) == (
+        "inventory",
+        "time",
+    )
+
+    with pytest.raises(QualityDiscoveryError, match="cannot be combined"):
+        normalize_quality_check_groups(("all", "inventory"))
+    with pytest.raises(QualityDiscoveryError, match="unsupported"):
+        normalize_quality_check_groups(("bad-group",))

--- a/tests/unit/test_data_quality_engine.py
+++ b/tests/unit/test_data_quality_engine.py
@@ -1,0 +1,271 @@
+"""Tests for the data-quality assessment engine contracts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from histdatacom.data_quality import (
+    QualityFinding,
+    QualityLocation,
+    QualityReport,
+    QualityRuleResult,
+    QualityRunSummary,
+    QualitySeverity,
+    QualityStatus,
+    QualityTarget,
+    QualityTargetKind,
+    QualityTargetSummary,
+    run_quality_assessment,
+)
+from histdatacom.histdata_ascii import M1
+from tests.fixtures.histdata_ascii.quality_cases import (
+    CLEAN_M1_CASE,
+    HistDataAsciiCase,
+    case_by_name,
+    write_ascii_case,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class _StaticRule:
+    rule_id: str
+    description: str
+    severity_by_case: dict[str, QualitySeverity | None]
+
+    def evaluate(self, target: QualityTarget) -> tuple[QualityFinding, ...]:
+        severity = self.severity_by_case.get(str(target.metadata["case"]))
+        if severity is None:
+            return ()
+        return (
+            QualityFinding(
+                severity=severity,
+                code=f"TEST_{severity.value.upper()}",
+                message=f"{self.rule_id} found {severity.value}",
+                rule_id=self.rule_id,
+                target=target,
+                location=QualityLocation(
+                    path=target.path,
+                    row_number=1,
+                    timestamp_source="20120201 000000",
+                    timestamp_utc_ms=1328072400000,
+                    column="datetime",
+                    metadata={"case": target.metadata["case"]},
+                ),
+                metadata={"rule": self.rule_id},
+            ),
+        )
+
+
+def test_quality_target_and_finding_round_trip_preserves_context(
+    tmp_path: Path,
+) -> None:
+    """Findings should carry file, row, timestamp, symbol, and check context."""
+    target = _target_for_case(tmp_path, CLEAN_M1_CASE)
+    finding = QualityFinding(
+        severity=QualitySeverity.WARNING,
+        code="M1_DUPLICATE_TIMESTAMP",
+        message="duplicate minute bar timestamp",
+        rule_id="m1.timestamp.unique",
+        target=target,
+        location=QualityLocation(
+            path=target.path,
+            row_number=2,
+            timestamp_source="20120201 000100",
+            timestamp_utc_ms=1328072460000,
+            column="datetime",
+            metadata={"source_timezone": "EST-no-DST"},
+        ),
+        metadata={"duplicate_of_row": 1},
+    )
+
+    restored_target = QualityTarget.from_dict(target.to_dict())
+    restored_finding = QualityFinding.from_dict(finding.to_dict())
+
+    assert restored_target == target
+    assert restored_finding == finding
+    assert restored_finding.target.symbol == "EURUSD"
+    assert restored_finding.target.timeframe == M1
+    assert restored_finding.location.row_number == 2
+    assert restored_finding.location.metadata["source_timezone"] == "EST-no-DST"
+
+
+def test_quality_engine_runs_multiple_rules_and_aggregates_status(
+    tmp_path: Path,
+) -> None:
+    """One engine path should aggregate clean, warning, and error findings."""
+    clean = _target_for_case(tmp_path, CLEAN_M1_CASE)
+    duplicate = _target_for_case(
+        tmp_path,
+        case_by_name("m1_duplicate_timestamp"),
+    )
+    missing = _target_for_case(tmp_path, case_by_name("m1_missing_file"))
+    rules = (
+        _StaticRule(
+            rule_id="manifest.case-observed",
+            description="records that each case was checked",
+            severity_by_case={
+                "clean_m1": QualitySeverity.INFO,
+                "m1_duplicate_timestamp": QualitySeverity.INFO,
+                "m1_missing_file": QualitySeverity.INFO,
+            },
+        ),
+        _StaticRule(
+            rule_id="m1.timestamp.unique",
+            description="flags duplicate timestamps",
+            severity_by_case={
+                "m1_duplicate_timestamp": QualitySeverity.WARNING,
+            },
+        ),
+        _StaticRule(
+            rule_id="file.exists",
+            description="flags missing files",
+            severity_by_case={"m1_missing_file": QualitySeverity.ERROR},
+        ),
+    )
+
+    report = run_quality_assessment(
+        targets=(clean, duplicate, missing),
+        rules=rules,
+        metadata={"request_id": "run-test"},
+    )
+
+    assert len(report.rule_results) == 9
+    assert [result.status for result in report.rule_results].count(
+        QualityStatus.CLEAN
+    ) == 7
+    assert report.summary() == QualityRunSummary(
+        target_count=3,
+        rule_count=3,
+        finding_count=5,
+        info_count=3,
+        warning_count=1,
+        error_count=1,
+        status=QualityStatus.FAILED,
+        max_severity=QualitySeverity.ERROR,
+    )
+    assert report.status == QualityStatus.FAILED
+    assert report.max_severity == QualitySeverity.ERROR
+    assert report.metadata == {"request_id": "run-test"}
+    assert report.target_summaries == (
+        QualityTargetSummary(
+            target=clean,
+            rule_count=3,
+            finding_count=1,
+            info_count=1,
+            warning_count=0,
+            error_count=0,
+            status=QualityStatus.CLEAN,
+            max_severity=QualitySeverity.INFO,
+        ),
+        QualityTargetSummary(
+            target=duplicate,
+            rule_count=3,
+            finding_count=2,
+            info_count=1,
+            warning_count=1,
+            error_count=0,
+            status=QualityStatus.WARNING,
+            max_severity=QualitySeverity.WARNING,
+        ),
+        QualityTargetSummary(
+            target=missing,
+            rule_count=3,
+            finding_count=2,
+            info_count=1,
+            warning_count=0,
+            error_count=1,
+            status=QualityStatus.FAILED,
+            max_severity=QualitySeverity.ERROR,
+        ),
+    )
+
+
+def test_quality_report_round_trip_recomputes_summary_state(
+    tmp_path: Path,
+) -> None:
+    """Serialized reports should restore findings and aggregate status."""
+    target = _target_for_case(tmp_path, case_by_name("m1_ohlc_violation"))
+    report = run_quality_assessment(
+        targets=(target,),
+        rules=(
+            _StaticRule(
+                rule_id="m1.ohlc.valid",
+                description="flags invalid OHLC ordering",
+                severity_by_case={"m1_ohlc_violation": QualitySeverity.ERROR},
+            ),
+        ),
+    )
+
+    restored = QualityReport.from_dict(report.to_dict())
+
+    assert restored == report
+    assert restored.summary().to_dict() == report.to_dict()["summary"]
+    assert restored.target_summaries[0].status == QualityStatus.FAILED
+    assert restored.rule_results[0] == QualityRuleResult.from_dict(
+        report.rule_results[0].to_dict()
+    )
+
+
+def test_empty_quality_run_is_clean() -> None:
+    """A run with no evaluated targets or findings should aggregate as clean."""
+    report = run_quality_assessment(targets=(), rules=())
+
+    assert report.status == QualityStatus.CLEAN
+    assert report.max_severity == QualitySeverity.INFO
+    assert report.summary() == QualityRunSummary(
+        target_count=0,
+        rule_count=0,
+        finding_count=0,
+        info_count=0,
+        warning_count=0,
+        error_count=0,
+        status=QualityStatus.CLEAN,
+        max_severity=QualitySeverity.INFO,
+    )
+    assert report.to_dict()["target_summaries"] == []
+
+
+def test_quality_enums_normalize_aliases_and_reject_bad_values() -> None:
+    """Public enum constructors should be stable at API boundaries."""
+    assert QualitySeverity.from_value(None) == QualitySeverity.INFO
+    assert QualitySeverity.from_value("warn") == QualitySeverity.WARNING
+    assert QualitySeverity.from_value("fatal") == QualitySeverity.ERROR
+    assert (
+        QualitySeverity.max((QualitySeverity.INFO, "warning", "error"))
+        == QualitySeverity.ERROR
+    )
+    assert QualityStatus.from_value("passed") == QualityStatus.CLEAN
+    assert QualityStatus.from_value("failure") == QualityStatus.FAILED
+    assert QualityTargetKind.from_value("zip-file") == QualityTargetKind.ZIP
+    assert QualityTargetKind.from_value("parquet") == QualityTargetKind.CACHE
+    assert QualityTargetKind.from_value("not-a-kind") == (
+        QualityTargetKind.UNKNOWN
+    )
+
+    with pytest.raises(ValueError, match="unknown quality severity"):
+        QualitySeverity.from_value("critical")
+    with pytest.raises(ValueError, match="unknown quality status"):
+        QualityStatus.from_value("partial")
+
+
+def _target_for_case(
+    tmp_path: Path,
+    case: HistDataAsciiCase,
+) -> QualityTarget:
+    path = write_ascii_case(tmp_path, case)
+    return QualityTarget(
+        path=str(path),
+        kind=QualityTargetKind.CSV,
+        data_format="ascii",
+        timeframe=case.timeframe,
+        symbol="EURUSD",
+        period="201202",
+        metadata={
+            "case": case.name,
+            "anomalies": list(case.anomalies),
+            "missing": case.missing,
+        },
+    )

--- a/tests/unit/test_data_quality_reporting.py
+++ b/tests/unit/test_data_quality_reporting.py
@@ -1,0 +1,176 @@
+"""Tests for data-quality report output and exit policy helpers."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from histdatacom.data_quality import (
+    QUALITY_REPORT_SCHEMA_VERSION,
+    QualityExitPolicy,
+    QualityFinding,
+    QualityLocation,
+    QualityReport,
+    QualityRuleResult,
+    QualitySeverity,
+    QualityTarget,
+    QualityTargetKind,
+    format_quality_console_summary,
+    quality_report_to_json,
+    write_quality_report,
+)
+
+
+def test_quality_json_report_is_deterministic_and_investigable(
+    tmp_path: Path,
+) -> None:
+    """JSON reports should be stable and include finding context."""
+    report = _mixed_report(tmp_path)
+    first = quality_report_to_json(report)
+    second = quality_report_to_json(report)
+
+    assert first == second
+
+    payload = json.loads(first)
+    finding = payload["rule_results"][1]["findings"][0]
+
+    assert payload["schema_version"] == QUALITY_REPORT_SCHEMA_VERSION
+    assert payload["summary"] == {
+        "error_count": 1,
+        "finding_count": 2,
+        "info_count": 0,
+        "max_severity": "error",
+        "rule_count": 2,
+        "status": "failed",
+        "target_count": 3,
+        "warning_count": 1,
+    }
+    assert finding["location"]["path"].endswith("warning.csv")
+    assert finding["location"]["row_number"] == 7
+    assert finding["location"]["timestamp_source"] == "20120201 000600"
+    assert finding["location"]["timestamp_utc_ms"] == 1328072760000
+    assert finding["target"]["symbol"] == "EURUSD"
+
+
+def test_quality_report_writer_returns_sidecar_artifact_ref(
+    tmp_path: Path,
+) -> None:
+    """Written reports should have a stable quality-report artifact surface."""
+    report = _mixed_report(tmp_path)
+    output = tmp_path / "reports" / "quality.json"
+
+    artifact = write_quality_report(report, output)
+
+    assert artifact.kind == "quality-report"
+    assert artifact.path == str(output.resolve())
+    assert artifact.size_bytes == output.stat().st_size
+    assert len(artifact.sha256) == 64
+    assert artifact.metadata["schema_version"] == QUALITY_REPORT_SCHEMA_VERSION
+    assert artifact.metadata["status"] == "failed"
+    assert artifact.metadata["target_count"] == 3
+    assert (
+        json.loads(output.read_text(encoding="utf-8"))["summary"]["error_count"]
+        == 1
+    )
+
+
+def test_quality_console_summary_separates_target_statuses(
+    tmp_path: Path,
+) -> None:
+    """Human output should group clean, warning, and failed files."""
+    output = format_quality_console_summary(
+        _mixed_report(tmp_path),
+        check_groups=("inventory", "time"),
+    )
+
+    assert "Data quality assessment" in output
+    assert "checks: inventory, time" in output
+    assert "status: failed" in output
+    assert "targets: 3 clean: 1 warning: 1 failed: 1" in output
+    assert "Clean files\n- csv:" in output
+    assert "Warning files\n- csv:" in output
+    assert "Failed files\n- csv:" in output
+
+
+def test_quality_exit_policy_applies_error_warning_and_never_modes(
+    tmp_path: Path,
+) -> None:
+    """Exit decisions should be derived from configured thresholds."""
+    summary = _mixed_report(tmp_path).summary()
+
+    assert QualityExitPolicy.from_values().evaluate(summary).exit_code == 1
+    assert (
+        QualityExitPolicy.from_values(max_errors=1).evaluate(summary).exit_code
+        == 0
+    )
+    assert (
+        QualityExitPolicy.from_values(
+            fail_on="warning",
+            max_errors=1,
+            max_warnings=0,
+        )
+        .evaluate(summary)
+        .reason
+        == "quality warning threshold exceeded: 1 > 0"
+    )
+    assert (
+        QualityExitPolicy.from_values(fail_on="never")
+        .evaluate(summary)
+        .exit_code
+        == 0
+    )
+
+
+def _mixed_report(tmp_path: Path) -> QualityReport:
+    clean = _target(tmp_path / "clean.csv")
+    warning = _target(tmp_path / "warning.csv")
+    failed = _target(tmp_path / "failed.csv")
+    warning_finding = QualityFinding(
+        severity=QualitySeverity.WARNING,
+        code="M1_DUPLICATE_TIMESTAMP",
+        message="duplicate minute bar timestamp",
+        rule_id="m1.timestamp.unique",
+        target=warning,
+        location=QualityLocation(
+            path=warning.path,
+            row_number=7,
+            timestamp_source="20120201 000600",
+            timestamp_utc_ms=1328072760000,
+            column="datetime",
+        ),
+    )
+    error_finding = QualityFinding(
+        severity=QualitySeverity.ERROR,
+        code="FILE_MISSING",
+        message="expected local file is missing",
+        rule_id="file.exists",
+        target=failed,
+        location=QualityLocation(path=failed.path),
+    )
+    return QualityReport(
+        targets=(clean, warning, failed),
+        rule_results=(
+            QualityRuleResult(rule_id="file.exists", target=clean),
+            QualityRuleResult(
+                rule_id="m1.timestamp.unique",
+                target=warning,
+                findings=(warning_finding,),
+            ),
+            QualityRuleResult(
+                rule_id="file.exists",
+                target=failed,
+                findings=(error_finding,),
+            ),
+        ),
+    )
+
+
+def _target(path: Path) -> QualityTarget:
+    return QualityTarget(
+        path=str(path),
+        kind=QualityTargetKind.CSV,
+        data_format="ascii",
+        timeframe="M1",
+        symbol="EURUSD",
+        period="201202",
+    )

--- a/tests/unit/test_histdata_com.py
+++ b/tests/unit/test_histdata_com.py
@@ -9,6 +9,7 @@ from types import SimpleNamespace
 import pytest
 
 import histdatacom
+from histdatacom.exceptions import InfluxConfigurationError
 from histdatacom.options import Options
 from histdatacom.runtime_contracts import WorkStatus
 from histdatacom.sidecar.client import (
@@ -351,6 +352,19 @@ def test_back_to_back_cli_sidecar_requests_use_fresh_parser_state(
         "submit_run_request_and_observe_sync",
         fake_submit,
     )
+    (tmp_path / "influxdb.yaml").write_text(
+        "\n".join(
+            [
+                "influxdb:",
+                "  org: org",
+                "  bucket: bucket",
+                "  url: http://127.0.0.1:8086",
+                "  token: token",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(
         sys,
         "argv",
@@ -403,8 +417,14 @@ def test_back_to_back_cli_sidecar_requests_use_fresh_parser_state(
     assert first_request.pairs == ("eurusd",)
     assert first_request.timeframes == ("M1",)
     assert first_request.data_directory == str(tmp_path / "first")
+    assert first_request.validate_urls
+    assert first_request.download_data_archives
+    assert first_request.extract_csvs
     assert first_request.import_to_influxdb
     assert first_request.delete_after_influx
+    assert first_request.metadata["influx_config"]["INFLUX_BUCKET"] == (
+        "bucket"
+    )
     assert first_kwargs == {
         "start_if_needed": False,
         "wait_for_result": False,
@@ -599,6 +619,95 @@ def test_api_sidecar_repository_request_returns_available_data(
         "start_if_needed": True,
         "wait_for_result": True,
     }
+
+
+def test_influx_cli_config_is_captured_before_sidecar_handoff(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Influx imports should use the caller cwd, not the worker cwd."""
+    import histdatacom.histdata_com as histdata_com
+
+    (tmp_path / "influxdb.yaml").write_text(
+        "\n".join(
+            [
+                "influxdb:",
+                "  org: org",
+                "  bucket: bucket",
+                "  url: http://127.0.0.1:8086",
+                "  token: token",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    captured: dict[str, object] = {}
+
+    def fake_submit(request, **kwargs: object) -> SidecarJobResult:
+        captured["request"] = request
+        captured["kwargs"] = kwargs
+        return _job_result()
+
+    monkeypatch.setattr(
+        histdata_com,
+        "submit_run_request_and_observe_sync",
+        fake_submit,
+    )
+    options = _sidecar_options()
+    options.import_to_influxdb = True
+
+    histdata_com.main(options)
+
+    request = captured["request"]
+    assert request.validate_urls is True
+    assert request.download_data_archives is True
+    assert request.extract_csvs is True
+    assert request.import_to_influxdb is True
+    assert request.metadata["influx_config"] == {
+        "INFLUX_ORG": "org",
+        "INFLUX_BUCKET": "bucket",
+        "INFLUX_URL": "http://127.0.0.1:8086",
+        "INFLUX_TOKEN": "token",
+    }
+    assert captured["kwargs"] == {
+        "start_if_needed": True,
+        "wait_for_result": True,
+    }
+
+
+def test_influx_cli_config_validation_happens_before_sidecar_handoff(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Malformed Influx config should fail in the caller process."""
+    import histdatacom.histdata_com as histdata_com
+
+    (tmp_path / "influxdb.yaml").write_text(
+        "\n".join(
+            [
+                "influxdb:",
+                "  org: org",
+                "  bucket: bucket",
+                "  url: http://127.0.0.1:8086",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+
+    def fail_submit(*args: object, **kwargs: object) -> None:
+        raise AssertionError("malformed config should not submit to sidecar")
+
+    monkeypatch.setattr(
+        histdata_com,
+        "submit_run_request_and_observe_sync",
+        fail_submit,
+    )
+    options = _sidecar_options()
+    options.import_to_influxdb = True
+
+    with pytest.raises(InfluxConfigurationError, match="token"):
+        histdata_com.main(options)
 
 
 def test_api_sidecar_repository_failure_returns_available_data(

--- a/tests/unit/test_histdata_com.py
+++ b/tests/unit/test_histdata_com.py
@@ -9,6 +9,13 @@ from types import SimpleNamespace
 import pytest
 
 import histdatacom
+from histdatacom.data_quality import (
+    QualityFinding,
+    QualityLocation,
+    QualityReport,
+    QualityRuleResult,
+    QualitySeverity,
+)
 from histdatacom.exceptions import InfluxConfigurationError
 from histdatacom.options import Options
 from histdatacom.runtime_contracts import WorkStatus
@@ -274,7 +281,7 @@ def test_data_quality_cli_discovers_local_targets_without_sidecar(
     assert histdata_com.main() is None
 
     output = capsys.readouterr().out
-    assert "Data quality target discovery" in output
+    assert "Data quality assessment" in output
     assert expected_text in output
     assert f"targets: {expected_count}" in output
 
@@ -339,6 +346,112 @@ def test_data_quality_api_returns_discovery_payload_without_sidecar(
     assert result["check_groups"] == ["inventory"]
     assert result["discovery"]["target_count"] == 1
     assert result["summary"]["target_count"] == 1
+    assert result["report_artifact"] is None
+    assert result["exit_decision"]["exit_code"] == 0
+
+
+def test_data_quality_cli_writes_json_report_artifact(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    """Quality CLI should write a full JSON report when requested."""
+    import histdatacom.histdata_com as histdata_com
+
+    csv_path = write_ascii_case(tmp_path, CLEAN_M1_CASE)
+    report_path = tmp_path / "reports" / "quality.json"
+    monkeypatch.setattr(
+        histdata_com,
+        "submit_run_request_and_observe_sync",
+        lambda *args, **kwargs: pytest.fail(
+            "quality mode should not submit to sidecar"
+        ),
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "histdatacom",
+            "--quality",
+            "--quality-target",
+            str(csv_path),
+            "--quality-report",
+            str(report_path),
+        ],
+    )
+
+    assert histdata_com.main() is None
+
+    output = capsys.readouterr().out
+    assert "Clean files" in output
+    assert "Warning files\n- none" in output
+    assert "Failed files\n- none" in output
+    assert f"report: {report_path.resolve()}" in output
+    assert '"schema_version": "histdatacom.quality-report.v1"' in (
+        report_path.read_text(encoding="utf-8")
+    )
+
+
+def test_data_quality_cli_exit_policy_fails_on_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    """Quality CLI should exit non-zero when findings exceed policy."""
+    import histdatacom.histdata_com as histdata_com
+
+    csv_path = write_ascii_case(tmp_path, CLEAN_M1_CASE)
+
+    def fake_assessment(targets, rules, *, metadata=None):
+        target = tuple(targets)[0]
+        finding = QualityFinding(
+            severity=QualitySeverity.ERROR,
+            code="FILE_MISSING",
+            message="expected local file is missing",
+            rule_id="file.exists",
+            target=target,
+            location=QualityLocation(path=target.path),
+        )
+        return QualityReport(
+            targets=(target,),
+            rule_results=(
+                QualityRuleResult(
+                    rule_id="file.exists",
+                    target=target,
+                    findings=(finding,),
+                ),
+            ),
+            metadata=dict(metadata or {}),
+        )
+
+    monkeypatch.setattr(
+        histdata_com,
+        "submit_run_request_and_observe_sync",
+        lambda *args, **kwargs: pytest.fail(
+            "quality mode should not submit to sidecar"
+        ),
+    )
+    monkeypatch.setattr(histdata_com, "run_quality_assessment", fake_assessment)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "histdatacom",
+            "--quality",
+            "--quality-target",
+            str(csv_path),
+            "--quality-fail-on",
+            "error",
+        ],
+    )
+
+    with pytest.raises(SystemExit) as err:
+        histdata_com.main()
+
+    assert err.value.code == 1
+    output = capsys.readouterr().out
+    assert "status: failed" in output
+    assert "Failed files\n- csv:" in output
 
 
 def test_back_to_back_sidecar_api_calls_do_not_leak_global_args(

--- a/tests/unit/test_histdata_com.py
+++ b/tests/unit/test_histdata_com.py
@@ -18,6 +18,11 @@ from histdatacom.sidecar.client import (
     SidecarUnavailableError,
     TemporalDependencyError,
 )
+from tests.fixtures.histdata_ascii.quality_cases import (
+    CLEAN_M1_CASE,
+    write_ascii_case,
+    write_zip_case,
+)
 
 
 def test_histdata_com() -> None:
@@ -213,6 +218,127 @@ def test_api_options_can_submit_sidecar_job_and_return_result(
         "start_if_needed": True,
         "wait_for_result": True,
     }
+
+
+@pytest.mark.parametrize(
+    ("target_kind", "expected_count", "expected_text"),
+    (
+        ("directory", 2, "targets: 2"),
+        ("csv", 1, "csv:"),
+        ("zip", 1, "zip:"),
+        ("empty-directory", 0, "No data quality targets discovered."),
+    ),
+)
+def test_data_quality_cli_discovers_local_targets_without_sidecar(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+    target_kind: str,
+    expected_count: int,
+    expected_text: str,
+) -> None:
+    """Quality CLI should discover local targets without starting sidecar."""
+    import histdatacom.histdata_com as histdata_com
+
+    root = tmp_path / target_kind
+    root.mkdir()
+    csv_path = write_ascii_case(root, CLEAN_M1_CASE)
+    zip_path = write_zip_case(root, CLEAN_M1_CASE)
+    target_path = {
+        "directory": root,
+        "csv": csv_path,
+        "zip": zip_path,
+        "empty-directory": tmp_path / "empty",
+    }[target_kind]
+    if target_kind == "empty-directory":
+        target_path.mkdir()
+
+    monkeypatch.setattr(
+        histdata_com,
+        "submit_run_request_and_observe_sync",
+        lambda *args, **kwargs: pytest.fail(
+            "quality mode should not submit to sidecar"
+        ),
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "histdatacom",
+            "--quality",
+            "--quality-target",
+            str(target_path),
+        ],
+    )
+
+    assert histdata_com.main() is None
+
+    output = capsys.readouterr().out
+    assert "Data quality target discovery" in output
+    assert expected_text in output
+    assert f"targets: {expected_count}" in output
+
+
+def test_data_quality_cli_missing_path_exits_without_sidecar(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    """Missing quality targets should fail locally before any sidecar call."""
+    import histdatacom.histdata_com as histdata_com
+
+    monkeypatch.setattr(
+        histdata_com,
+        "submit_run_request_and_observe_sync",
+        lambda *args, **kwargs: pytest.fail(
+            "quality mode should not submit to sidecar"
+        ),
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "histdatacom",
+            "--quality",
+            "--quality-target",
+            str(tmp_path / "missing"),
+        ],
+    )
+
+    with pytest.raises(SystemExit) as err:
+        histdata_com.main()
+
+    assert err.value.code == 1
+    assert "quality target path does not exist" in capsys.readouterr().err
+
+
+def test_data_quality_api_returns_discovery_payload_without_sidecar(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """API quality runs should return the same bounded discovery payload."""
+    import histdatacom.histdata_com as histdata_com
+
+    csv_path = write_ascii_case(tmp_path, CLEAN_M1_CASE)
+    options = Options()
+    options.data_quality = True
+    options.quality_paths = (str(csv_path),)
+    options.quality_check_groups = {"inventory"}
+
+    monkeypatch.setattr(
+        histdata_com,
+        "submit_run_request_and_observe_sync",
+        lambda *args, **kwargs: pytest.fail(
+            "quality mode should not submit to sidecar"
+        ),
+    )
+
+    result = histdata_com.main(options)
+
+    assert result["operation"] == "data-quality"
+    assert result["check_groups"] == ["inventory"]
+    assert result["discovery"]["target_count"] == 1
+    assert result["summary"]["target_count"] == 1
 
 
 def test_back_to_back_sidecar_api_calls_do_not_leak_global_args(

--- a/tests/unit/test_histdata_quality_fixtures.py
+++ b/tests/unit/test_histdata_quality_fixtures.py
@@ -1,0 +1,386 @@
+"""Coverage for reusable HistData ASCII data-quality fixture cases."""
+
+from __future__ import annotations
+
+import csv
+import zipfile
+from collections import Counter
+from io import StringIO
+from pathlib import Path
+
+import pytest
+
+from histdatacom.histdata_ascii import (
+    M1,
+    TICK,
+    columns_for_timeframe,
+    delimiter_for_timeframe,
+    parse_histdata_datetime_to_utc_ms,
+    polars_datetime_to_utc_ms_expr,
+)
+from tests.fixtures.histdata_ascii.quality_cases import (
+    ALL_ASCII_CASES,
+    ALL_CLEAN_CASES,
+    ALL_DIRTY_CASES,
+    CLEAN_M1_CASE,
+    CLEAN_M1_FIXTURE,
+    CLEAN_TICK_CASE,
+    CLEAN_TICK_FIXTURE,
+    DIRTY_M1_CASES,
+    DIRTY_TICK_CASES,
+    EST_NO_DST_CALENDAR_CASES,
+    HistDataAsciiCase,
+    case_by_name,
+    copy_clean_fixture,
+    write_ascii_case,
+    write_corrupt_zip,
+    write_zip_case,
+)
+
+
+def test_quality_case_index_covers_clean_and_dirty_m1_and_tick_cases() -> None:
+    """The fixture suite should expose clean and dirty cases for both layouts."""
+    assert ALL_CLEAN_CASES == (CLEAN_M1_CASE, CLEAN_TICK_CASE)
+    assert {case.timeframe for case in ALL_CLEAN_CASES} == {M1, TICK}
+    assert {case.timeframe for case in DIRTY_M1_CASES} == {M1}
+    assert {case.timeframe for case in DIRTY_TICK_CASES} == {TICK}
+    assert len(ALL_ASCII_CASES) == len(ALL_CLEAN_CASES) + len(ALL_DIRTY_CASES)
+
+    m1_anomalies = _anomaly_names(DIRTY_M1_CASES)
+    tick_anomalies = _anomaly_names(DIRTY_TICK_CASES)
+    assert {
+        "malformed_row",
+        "bad_timestamp",
+        "duplicate_timestamp",
+        "non_monotonic_timestamp",
+        "ohlc_violation",
+        "header_row",
+        "bad_delimiter",
+        "empty_file",
+        "missing_file",
+    } <= m1_anomalies
+    assert {
+        "malformed_row",
+        "bad_timestamp",
+        "duplicate_tick",
+        "duplicate_timestamp",
+        "non_monotonic_timestamp",
+        "negative_spread",
+        "header_row",
+        "bad_delimiter",
+        "empty_file",
+        "missing_file",
+    } <= tick_anomalies
+
+
+@pytest.mark.parametrize(
+    ("case", "source"),
+    (
+        (CLEAN_M1_CASE, CLEAN_M1_FIXTURE),
+        (CLEAN_TICK_CASE, CLEAN_TICK_FIXTURE),
+    ),
+    ids=lambda item: item.name if isinstance(item, HistDataAsciiCase) else None,
+)
+def test_clean_quality_cases_match_static_histdata_ascii_fixtures(
+    case: HistDataAsciiCase,
+    source: Path,
+) -> None:
+    """The reusable clean cases should not drift from the static fixtures."""
+    assert case.text == source.read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize(
+    "case",
+    ALL_ASCII_CASES,
+    ids=lambda case: case.name,
+)
+def test_ascii_quality_case_builder_writes_expected_targets(
+    tmp_path: Path,
+    case: HistDataAsciiCase,
+) -> None:
+    """Fixture builders should support clean, dirty, empty, and missing files."""
+    path = write_ascii_case(tmp_path, case)
+
+    assert path == tmp_path / case.filename
+    if case.missing:
+        assert not path.exists()
+        return
+
+    assert path.read_text(encoding="utf-8") == case.text
+    if "empty_file" in case.anomalies:
+        assert path.stat().st_size == 0
+
+
+@pytest.mark.parametrize(
+    "timeframe",
+    (M1, TICK),
+)
+def test_clean_fixture_copy_builder_reuses_static_fixture_files(
+    tmp_path: Path,
+    timeframe: str,
+) -> None:
+    """Quality tests can copy the existing clean CSV fixtures into temp dirs."""
+    copied = copy_clean_fixture(tmp_path, timeframe)
+    source = CLEAN_M1_FIXTURE if timeframe == M1 else CLEAN_TICK_FIXTURE
+
+    assert copied.name == source.name
+    assert copied.read_text(encoding="utf-8") == source.read_text(
+        encoding="utf-8"
+    )
+
+
+def test_zip_quality_case_builder_writes_valid_single_member_archive(
+    tmp_path: Path,
+) -> None:
+    """Future ZIP checks can start from a valid HistData archive fixture."""
+    archive_path = write_zip_case(tmp_path, CLEAN_M1_CASE)
+
+    with zipfile.ZipFile(archive_path, "r") as archive:
+        assert archive.namelist() == [CLEAN_M1_CASE.filename]
+        assert (
+            archive.read(CLEAN_M1_CASE.filename).decode("utf-8")
+            == CLEAN_M1_CASE.text
+        )
+
+
+def test_zip_quality_builders_cover_corrupt_and_extra_member_archives(
+    tmp_path: Path,
+) -> None:
+    """Future archive checks need corrupt and ambiguous archive inputs."""
+    corrupt_path = write_corrupt_zip(tmp_path)
+    with pytest.raises(zipfile.BadZipFile):
+        with zipfile.ZipFile(corrupt_path, "r") as archive:
+            archive.testzip()
+
+    extra_path = write_zip_case(
+        tmp_path,
+        CLEAN_TICK_CASE,
+        extra_members=(("README.txt", "unexpected metadata"),),
+    )
+    with zipfile.ZipFile(extra_path, "r") as archive:
+        assert set(archive.namelist()) == {
+            CLEAN_TICK_CASE.filename,
+            "README.txt",
+        }
+
+
+@pytest.mark.parametrize(
+    "case",
+    ALL_DIRTY_CASES,
+    ids=lambda case: case.name,
+)
+def test_dirty_ascii_cases_contain_declared_anomalies(
+    tmp_path: Path,
+    case: HistDataAsciiCase,
+) -> None:
+    """Dirty fixture labels should correspond to observable raw-data defects."""
+    path = write_ascii_case(tmp_path, case)
+
+    for anomaly in case.anomalies:
+        assert _has_declared_anomaly(case, path, anomaly), (
+            case.name,
+            anomaly,
+        )
+
+
+@pytest.mark.parametrize(
+    "case_name",
+    ("clean_m1", "m1_ohlc_violation", "tick_negative_spread"),
+)
+def test_quality_cases_can_be_looked_up_by_stable_case_name(
+    case_name: str,
+) -> None:
+    """Future rule tests can select focused fixture cases by stable name."""
+    assert case_by_name(case_name).name == case_name
+
+
+def test_unknown_quality_case_name_fails_clearly() -> None:
+    """Misspelled fixture names should fail at test setup time."""
+    with pytest.raises(KeyError, match="missing_case"):
+        case_by_name("missing_case")
+
+
+@pytest.mark.parametrize(
+    "case",
+    EST_NO_DST_CALENDAR_CASES,
+    ids=lambda case: f"{case.timeframe}-{case.description}",
+)
+def test_est_no_dst_calendar_fixture_cases_use_fixed_utc_offset(
+    case,
+) -> None:
+    """Shared calendar fixtures should preserve HistData EST-no-DST semantics."""
+    assert (
+        parse_histdata_datetime_to_utc_ms(case.raw, case.timeframe)
+        == case.expected_utc_ms
+    )
+
+
+@pytest.mark.parametrize(
+    "timeframe",
+    (M1, TICK),
+)
+def test_est_no_dst_calendar_fixture_cases_match_polars_expression(
+    timeframe: str,
+) -> None:
+    """Vectorized timestamp checks should consume the same calendar fixtures."""
+    import polars as pl
+
+    cases = [
+        case
+        for case in EST_NO_DST_CALENDAR_CASES
+        if case.timeframe == timeframe
+    ]
+    frame = pl.DataFrame({"datetime": [case.raw for case in cases]})
+
+    assert frame.select(
+        polars_datetime_to_utc_ms_expr(timeframe)
+    ).to_series().to_list() == [case.expected_utc_ms for case in cases]
+
+
+def _anomaly_names(
+    cases: tuple[HistDataAsciiCase, ...],
+) -> set[str]:
+    return {anomaly for case in cases for anomaly in case.anomalies}
+
+
+def _rows(case: HistDataAsciiCase) -> list[list[str]]:
+    return list(
+        csv.reader(
+            StringIO(case.text),
+            delimiter=delimiter_for_timeframe(case.timeframe),
+        )
+    )
+
+
+def _has_declared_anomaly(
+    case: HistDataAsciiCase,
+    path: Path,
+    anomaly: str,
+) -> bool:
+    match anomaly:
+        case "malformed_row":
+            return _has_malformed_row(case)
+        case "bad_timestamp":
+            return _has_bad_timestamp(case)
+        case "duplicate_timestamp":
+            return _has_duplicate_timestamp(case)
+        case "duplicate_tick":
+            return _has_duplicate_tick(case)
+        case "non_monotonic_timestamp":
+            return _has_non_monotonic_timestamp(case)
+        case "ohlc_violation":
+            return _has_m1_ohlc_violation(case)
+        case "negative_spread":
+            return _has_negative_spread(case)
+        case "header_row":
+            return _has_header_row(case)
+        case "bad_delimiter":
+            return _has_bad_delimiter(case)
+        case "empty_file":
+            return path.exists() and path.stat().st_size == 0
+        case "missing_file":
+            return not path.exists()
+        case _:
+            raise AssertionError(f"unknown anomaly marker: {anomaly}")
+
+
+def _has_malformed_row(case: HistDataAsciiCase) -> bool:
+    expected = len(columns_for_timeframe(case.timeframe))
+    return any(len(row) != expected for row in _rows(case))
+
+
+def _has_bad_timestamp(case: HistDataAsciiCase) -> bool:
+    expected = len(columns_for_timeframe(case.timeframe))
+    for row in _rows(case):
+        if len(row) != expected:
+            continue
+        try:
+            parse_histdata_datetime_to_utc_ms(row[0], case.timeframe)
+        except ValueError:
+            return True
+    return False
+
+
+def _valid_timestamp_values(case: HistDataAsciiCase) -> list[int]:
+    expected = len(columns_for_timeframe(case.timeframe))
+    values: list[int] = []
+    for row in _rows(case):
+        if len(row) != expected:
+            continue
+        try:
+            values.append(
+                parse_histdata_datetime_to_utc_ms(row[0], case.timeframe)
+            )
+        except ValueError:
+            continue
+    return values
+
+
+def _raw_valid_timestamp_values(case: HistDataAsciiCase) -> list[str]:
+    expected = len(columns_for_timeframe(case.timeframe))
+    return [row[0] for row in _rows(case) if len(row) == expected]
+
+
+def _has_duplicate_timestamp(case: HistDataAsciiCase) -> bool:
+    counts = Counter(_raw_valid_timestamp_values(case))
+    return any(count > 1 for count in counts.values())
+
+
+def _has_duplicate_tick(case: HistDataAsciiCase) -> bool:
+    rows = [tuple(row) for row in _rows(case)]
+    counts = Counter(rows)
+    return any(count > 1 for count in counts.values())
+
+
+def _has_non_monotonic_timestamp(case: HistDataAsciiCase) -> bool:
+    values = _valid_timestamp_values(case)
+    return any(
+        current < previous for previous, current in zip(values, values[1:])
+    )
+
+
+def _has_m1_ohlc_violation(case: HistDataAsciiCase) -> bool:
+    if case.timeframe != M1:
+        return False
+    for row in _rows(case):
+        if len(row) != 6:
+            continue
+        try:
+            open_bid, high_bid, low_bid, close_bid = map(float, row[1:5])
+        except ValueError:
+            continue
+        if (
+            high_bid < max(open_bid, close_bid)
+            or low_bid > min(open_bid, close_bid)
+            or high_bid < low_bid
+        ):
+            return True
+    return False
+
+
+def _has_negative_spread(case: HistDataAsciiCase) -> bool:
+    if case.timeframe != TICK:
+        return False
+    for row in _rows(case):
+        if len(row) != 4:
+            continue
+        try:
+            bid, ask = float(row[1]), float(row[2])
+        except ValueError:
+            continue
+        if ask < bid:
+            return True
+    return False
+
+
+def _has_header_row(case: HistDataAsciiCase) -> bool:
+    rows = _rows(case)
+    return bool(rows and rows[0] == list(columns_for_timeframe(case.timeframe)))
+
+
+def _has_bad_delimiter(case: HistDataAsciiCase) -> bool:
+    expected_delimiter = delimiter_for_timeframe(case.timeframe)
+    wrong_delimiter = "," if expected_delimiter == ";" else ";"
+    return any(
+        len(row) == 1 and wrong_delimiter in row[0] for row in _rows(case)
+    )

--- a/tests/unit/test_sidecar_activities.py
+++ b/tests/unit/test_sidecar_activities.py
@@ -242,6 +242,7 @@ def _influx_payload(
     timeframe: str = "M1",
     batch_size: str = "2",
     delete_after_influx: bool = False,
+    influx_config: dict | None = None,
 ) -> dict:
     """Return an Influx activity payload with a cache artifact."""
     filename = f"DAT_ASCII_EURUSD_{timeframe}_201202.csv"
@@ -259,6 +260,7 @@ def _influx_payload(
         batch_size=batch_size,
         import_to_influxdb=True,
         delete_after_influx=delete_after_influx,
+        metadata={"influx_config": influx_config} if influx_config else {},
     )
     return {
         "request": request.to_dict(),
@@ -839,6 +841,38 @@ def test_import_to_influx_activity_writes_m1_batches(
     assert result["result"]["metrics"]["line_count"] == 3
     assert result["result"]["metrics"]["heartbeat_count"] == 2
     assert "data" not in result
+
+
+def test_import_to_influx_activity_uses_request_influx_config(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    """Sidecar workers should use caller-resolved Influx connection config."""
+    FakeInfluxWriter.instances.clear()
+    FakeInfluxWriter.fail_with = None
+    monkeypatch.setattr(
+        "histdatacom.sidecar.activities._influx_batch_writer",
+        FakeInfluxWriter,
+    )
+
+    result = import_to_influx_activity(
+        _influx_payload(
+            tmp_path,
+            influx_config={
+                "INFLUX_ORG": "org",
+                "INFLUX_BUCKET": "bucket",
+                "INFLUX_URL": "http://127.0.0.1:8086",
+                "INFLUX_TOKEN": "token",
+            },
+        )
+    )
+
+    [writer] = FakeInfluxWriter.instances
+    assert writer.args["INFLUX_ORG"] == "org"
+    assert writer.args["INFLUX_BUCKET"] == "bucket"
+    assert writer.args["INFLUX_URL"] == "http://127.0.0.1:8086"
+    assert writer.args["INFLUX_TOKEN"] == "token"
+    assert result["result"]["status"] == WorkStatus.INFLUX_UPLOAD.value
 
 
 def test_import_to_influx_activity_writes_tick_batches(

--- a/tests/unit/test_sidecar_cli.py
+++ b/tests/unit/test_sidecar_cli.py
@@ -11,7 +11,11 @@ import pytest
 from histdatacom.runtime_contracts import RunRequest, WorkStatus
 from histdatacom.sidecar import client as sidecar_client
 from histdatacom.sidecar import cli
-from histdatacom.sidecar.control import JobLifecycle, SidecarJobSnapshot
+from histdatacom.sidecar.control import (
+    JobLifecycle,
+    SidecarJobList,
+    SidecarJobSnapshot,
+)
 from histdatacom.sidecar.queues import build_sidecar_worker_config
 from histdatacom.sidecar.runtime import build_sidecar_runtime_policy
 
@@ -349,6 +353,80 @@ def test_sidecar_jobs_cli_resolves_config_from_running_supervisor(
     assert isinstance(inspect_kwargs, dict)
     assert inspect_kwargs["config"] is resolved_config
     assert inspect_kwargs["supervisor"] is supervisor
+
+
+@pytest.mark.parametrize(
+    "argv",
+    (
+        ["jobs", "--json", "list"],
+        ["jobs", "list", "--json"],
+    ),
+)
+def test_sidecar_jobs_list_accepts_json_before_or_after_subcommand(
+    argv: list[str],
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Documented job commands should accept JSON flags naturally."""
+    monkeypatch.setattr(
+        cli,
+        "_supervisor",
+        lambda args: _StatusOnlySupervisor("running"),
+    )
+    monkeypatch.setattr(cli, "_worker_config", lambda args: _FakeConfig())
+    monkeypatch.setattr(
+        cli,
+        "list_job_statuses_sync",
+        lambda **kwargs: SidecarJobList(jobs=(_snapshot(),)),
+    )
+
+    exit_code = cli.main(argv)
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert payload["jobs"][0]["workflow_id"] == "histdatacom-run-cli"
+
+
+@pytest.mark.parametrize(
+    "argv",
+    (
+        ["jobs", "--json", "--offline", "inspect", "histdatacom-run-cli"],
+        ["jobs", "inspect", "histdatacom-run-cli", "--json", "--offline"],
+    ),
+)
+def test_sidecar_jobs_inspect_accepts_shared_flags_after_subcommand(
+    argv: list[str],
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Offline and JSON flags should work in documented user order."""
+    captured: dict[str, object] = {}
+
+    def fake_inspect(
+        workflow_id: str,
+        **kwargs: object,
+    ) -> SidecarJobSnapshot:
+        captured["workflow_id"] = workflow_id
+        captured["kwargs"] = kwargs
+        return _snapshot()
+
+    monkeypatch.setattr(
+        cli,
+        "_supervisor",
+        lambda args: _StatusOnlySupervisor("stopped"),
+    )
+    monkeypatch.setattr(cli, "_worker_config", lambda args: _FakeConfig())
+    monkeypatch.setattr(cli, "inspect_job_status_sync", fake_inspect)
+
+    exit_code = cli.main(argv)
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert payload["workflow_id"] == "histdatacom-run-cli"
+    assert captured["workflow_id"] == "histdatacom-run-cli"
+    kwargs = captured["kwargs"]
+    assert isinstance(kwargs, dict)
+    assert kwargs["offline"] is True
 
 
 def test_sidecar_jobs_offline_cli_reads_persisted_store(


### PR DESCRIPTION
## Summary
- Merge the closed #120 data-quality reporting foundation into main.
- Includes deterministic JSON report output, bounded quality payloads, quality-report artifacts, console status grouping, and configurable exit policy.

## Validation
- venv/bin/python -m pytest: 554 passed
- venv/bin/pre-commit run --files <touched files>: passed
- live --quality --quality-report smoke passed

Issue: #120