### PR TITLE
[codex] add distribution fingerprints

### DIFF
--- a/src/histdatacom/data_quality/fingerprints.py
+++ b/src/histdatacom/data_quality/fingerprints.py
@@ -908,6 +908,10 @@ def _m1_bar_distribution_from_frame(
 ) -> dict[str, JSONValue]:
     row_count = int(getattr(frame, "height", 0) or 0)
     sample_limit = min(row_count, _profile_max_rows(profile))
+    usable_row_count = _frame_numeric_usable_row_count(
+        frame,
+        ("open", "high", "low", "close"),
+    )
     columns = {
         name: _frame_column_values(frame, name, sample_limit)
         for name in ("open", "high", "low", "close")
@@ -915,6 +919,7 @@ def _m1_bar_distribution_from_frame(
     return _m1_bar_distribution_from_column_values(
         columns,
         row_count=row_count,
+        usable_row_count=usable_row_count,
         sample_limit=sample_limit,
         profile=profile,
         precision_source="cache_float",
@@ -989,12 +994,13 @@ def _m1_bar_distribution_from_column_values(
     columns: Mapping[str, list[Any]],
     *,
     row_count: int,
+    usable_row_count: int,
     sample_limit: int,
     profile: HistDataFingerprintProfile,
     precision_source: str,
 ) -> dict[str, JSONValue]:
     sampled_rows: list[tuple[float, float, float, float]] = []
-    invalid_row_count = 0
+    sampled_invalid_row_count = 0
     sampled_count = min(
         sample_limit,
         *(
@@ -1018,7 +1024,7 @@ def _m1_bar_distribution_from_column_values(
                 break
             prices.append(value)
         if len(prices) != 4:
-            invalid_row_count += 1
+            sampled_invalid_row_count += 1
             continue
         sampled_rows.append((prices[0], prices[1], prices[2], prices[3]))
         for column_name, value in zip(
@@ -1034,10 +1040,12 @@ def _m1_bar_distribution_from_column_values(
         sampled_rows,
         row_count=row_count,
         usable_row_count=len(sampled_rows),
-        invalid_row_count=invalid_row_count,
-        truncated=row_count > sampled_count,
+        invalid_row_count=sampled_invalid_row_count,
+        truncated=usable_row_count > len(sampled_rows),
         profile=profile,
     )
+    payload["usable_row_count"] = usable_row_count
+    payload["invalid_row_count"] = max(0, row_count - usable_row_count)
     precision = cast(dict[str, JSONValue], payload["precision"])
     precision["precision_source"] = precision_source
     precision["decimal_place_counts"] = _counter_payload(precision_counts)
@@ -1137,12 +1145,14 @@ def _tick_distribution_from_frame(
 ) -> dict[str, JSONValue]:
     row_count = int(getattr(frame, "height", 0) or 0)
     sample_limit = min(row_count, _profile_max_rows(profile))
+    usable_row_count = _frame_numeric_usable_row_count(frame, ("bid", "ask"))
     bids = _frame_column_values(frame, "bid", sample_limit)
     asks = _frame_column_values(frame, "ask", sample_limit)
     return _tick_distribution_from_column_values(
         bids,
         asks,
         row_count=row_count,
+        usable_row_count=usable_row_count,
         sample_limit=sample_limit,
         profile=profile,
     )
@@ -1197,18 +1207,19 @@ def _tick_distribution_from_column_values(
     asks: list[Any],
     *,
     row_count: int,
+    usable_row_count: int,
     sample_limit: int,
     profile: HistDataFingerprintProfile,
 ) -> dict[str, JSONValue]:
     sampled_bids: list[float] = []
     sampled_asks: list[float] = []
-    invalid_row_count = 0
+    sampled_invalid_row_count = 0
     sampled_count = min(sample_limit, len(bids), len(asks))
     for index in range(sampled_count):
         bid = _finite_float(bids[index])
         ask = _finite_float(asks[index])
         if bid is None or ask is None:
-            invalid_row_count += 1
+            sampled_invalid_row_count += 1
             continue
         sampled_bids.append(bid)
         sampled_asks.append(ask)
@@ -1217,9 +1228,9 @@ def _tick_distribution_from_column_values(
         sampled_asks,
         row_count=row_count,
         sampled_row_count=len(sampled_bids),
-        usable_row_count=len(sampled_bids),
-        invalid_row_count=invalid_row_count,
-        truncated=row_count > sampled_count,
+        usable_row_count=usable_row_count,
+        invalid_row_count=max(0, row_count - usable_row_count),
+        truncated=usable_row_count > len(sampled_bids),
         profile=profile,
     )
 
@@ -1373,6 +1384,58 @@ def _frame_column_values(
         return cast(list[Any], series.head(limit).to_list())
     except AttributeError:
         return list(series)[:limit]
+
+
+def _frame_numeric_usable_row_count(
+    frame: Any,
+    columns: tuple[str, ...],
+) -> int:
+    try:
+        import polars as pl
+        from polars.exceptions import PolarsError
+    except ImportError:
+        return _frame_numeric_usable_row_count_fallback(frame, columns)
+
+    try:
+        expressions = [
+            pl.col(column).is_not_null() & pl.col(column).is_finite()
+            for column in columns
+        ]
+        value = frame.select(
+            pl.all_horizontal(*expressions).sum().alias("__usable_row_count")
+        ).item()
+    except (AttributeError, TypeError, ValueError, PolarsError):
+        return _frame_numeric_usable_row_count_fallback(frame, columns)
+    if isinstance(value, bool) or value is None:
+        return 0
+    try:
+        return max(0, int(value))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _frame_numeric_usable_row_count_fallback(
+    frame: Any,
+    columns: tuple[str, ...],
+) -> int:
+    row_count = int(getattr(frame, "height", 0) or 0)
+    if row_count <= 0:
+        return 0
+    column_values = {
+        column: _frame_column_values(frame, column, row_count)
+        for column in columns
+    }
+    scanned_count = min(
+        row_count, *(len(values) for values in column_values.values())
+    )
+    usable_count = 0
+    for index in range(scanned_count):
+        if all(
+            _finite_float(column_values[column][index]) is not None
+            for column in columns
+        ):
+            usable_count += 1
+    return usable_count
 
 
 def _profile_max_rows(profile: HistDataFingerprintProfile) -> int:

--- a/src/histdatacom/data_quality/fingerprints.py
+++ b/src/histdatacom/data_quality/fingerprints.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 import csv
 import hashlib
 import json
+import math
 import zipfile
 from collections import Counter
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field
+from decimal import Decimal, InvalidOperation, localcontext
 from pathlib import Path
 from typing import Any, cast
 
@@ -131,7 +133,7 @@ class HistDataSeriesFingerprintRule:
 
     def evaluate(self, target: QualityTarget) -> tuple[QualityFinding, ...]:
         """Return one bounded fingerprint finding for one target."""
-        payload = _series_fingerprint_payload(target)
+        payload = _series_fingerprint_payload(target, self.profile)
         source = cast(dict[str, JSONValue], payload["source"])
         unavailable = source.get("kind") == "unavailable"
         code = (
@@ -339,7 +341,10 @@ def series_fingerprint_topology_attention_summary(
     )
 
 
-def _series_fingerprint_payload(target: QualityTarget) -> dict[str, JSONValue]:
+def _series_fingerprint_payload(
+    target: QualityTarget,
+    profile: HistDataFingerprintProfile,
+) -> dict[str, JSONValue]:
     payload: dict[str, JSONValue] = {
         "schema_version": TIME_SERIES_FINGERPRINT_SCHEMA_VERSION,
         "target_axis": _target_axis(target),
@@ -358,6 +363,15 @@ def _series_fingerprint_payload(target: QualityTarget) -> dict[str, JSONValue]:
     cache = read_quality_polars_cache(target, required_columns=columns)
     if cache is not None:
         payload["coverage"] = _coverage_from_frame(cache.frame)
+        _add_distribution_payload(
+            payload,
+            timeframe=target.timeframe,
+            distribution=_distribution_from_frame(
+                cache.frame,
+                timeframe=target.timeframe,
+                profile=profile,
+            ),
+        )
         payload["source"] = {
             "kind": "cache",
             "cache_source": cache.source,
@@ -396,6 +410,15 @@ def _series_fingerprint_payload(target: QualityTarget) -> dict[str, JSONValue]:
     payload["coverage"] = _coverage_from_text(
         text_payload.text,
         timeframe=target.timeframe,
+    )
+    _add_distribution_payload(
+        payload,
+        timeframe=target.timeframe,
+        distribution=_distribution_from_text(
+            text_payload.text,
+            timeframe=target.timeframe,
+            profile=profile,
+        ),
     )
     if target.kind is QualityTargetKind.ZIP:
         payload["source"] = {
@@ -839,6 +862,540 @@ def _coverage_from_text(
             scan.start_timestamp_utc_ms = timestamp
         scan.end_timestamp_utc_ms = timestamp
     return scan.to_payload()
+
+
+def _add_distribution_payload(
+    payload: dict[str, JSONValue],
+    *,
+    timeframe: str,
+    distribution: dict[str, JSONValue],
+) -> None:
+    if timeframe == M1:
+        payload["m1_bar_distribution"] = distribution
+    elif timeframe == TICK:
+        payload["tick_distribution"] = distribution
+
+
+def _distribution_from_frame(
+    frame: Any,
+    *,
+    timeframe: str,
+    profile: HistDataFingerprintProfile,
+) -> dict[str, JSONValue]:
+    if timeframe == M1:
+        return _m1_bar_distribution_from_frame(frame, profile)
+    if timeframe == TICK:
+        return _tick_distribution_from_frame(frame, profile)
+    return {}
+
+
+def _distribution_from_text(
+    text: str,
+    *,
+    timeframe: str,
+    profile: HistDataFingerprintProfile,
+) -> dict[str, JSONValue]:
+    if timeframe == M1:
+        return _m1_bar_distribution_from_text(text, profile)
+    if timeframe == TICK:
+        return _tick_distribution_from_text(text, profile)
+    return {}
+
+
+def _m1_bar_distribution_from_frame(
+    frame: Any,
+    profile: HistDataFingerprintProfile,
+) -> dict[str, JSONValue]:
+    row_count = int(getattr(frame, "height", 0) or 0)
+    sample_limit = min(row_count, _profile_max_rows(profile))
+    columns = {
+        name: _frame_column_values(frame, name, sample_limit)
+        for name in ("open", "high", "low", "close")
+    }
+    return _m1_bar_distribution_from_column_values(
+        columns,
+        row_count=row_count,
+        sample_limit=sample_limit,
+        profile=profile,
+        precision_source="cache_float",
+    )
+
+
+def _m1_bar_distribution_from_text(
+    text: str,
+    profile: HistDataFingerprintProfile,
+) -> dict[str, JSONValue]:
+    row_count = 0
+    invalid_row_count = 0
+    usable_row_count = 0
+    sample_limit = _profile_max_rows(profile)
+    sampled_rows: list[tuple[float, float, float, float]] = []
+    precision_counts: Counter[str] = Counter()
+    column_precision_counts: dict[str, Counter[str]] = {
+        "open": Counter(),
+        "high": Counter(),
+        "low": Counter(),
+        "close": Counter(),
+    }
+    reader = csv.reader(
+        text.splitlines(), delimiter=delimiter_for_timeframe(M1)
+    )
+    for row in reader:
+        if not row or not any(cell.strip() for cell in row):
+            continue
+        row_count += 1
+        try:
+            parsed = normalize_ascii_row(M1, row)
+        except (TypeError, ValueError, OverflowError):
+            invalid_row_count += 1
+            continue
+        prices = tuple(float(parsed[index]) for index in range(1, 5))
+        if not all(_is_finite(value) for value in prices):
+            invalid_row_count += 1
+            continue
+        usable_row_count += 1
+        if len(sampled_rows) >= sample_limit:
+            continue
+        sampled_rows.append(cast(tuple[float, float, float, float], prices))
+        for column_name, raw_value in zip(
+            ("open", "high", "low", "close"),
+            row[1:5],
+            strict=True,
+        ):
+            places = _decimal_places_from_text(raw_value)
+            key = str(places)
+            precision_counts[key] += 1
+            column_precision_counts[column_name][key] += 1
+
+    payload = _m1_bar_distribution_from_rows(
+        sampled_rows,
+        row_count=row_count,
+        usable_row_count=usable_row_count,
+        invalid_row_count=invalid_row_count,
+        truncated=usable_row_count > len(sampled_rows),
+        profile=profile,
+    )
+    precision = cast(dict[str, JSONValue], payload["precision"])
+    precision["precision_source"] = "text"
+    precision["decimal_place_counts"] = _counter_payload(precision_counts)
+    precision["column_decimal_place_counts"] = {
+        column: _counter_payload(counts)
+        for column, counts in column_precision_counts.items()
+    }
+    return payload
+
+
+def _m1_bar_distribution_from_column_values(
+    columns: Mapping[str, list[Any]],
+    *,
+    row_count: int,
+    sample_limit: int,
+    profile: HistDataFingerprintProfile,
+    precision_source: str,
+) -> dict[str, JSONValue]:
+    sampled_rows: list[tuple[float, float, float, float]] = []
+    invalid_row_count = 0
+    sampled_count = min(
+        sample_limit,
+        *(
+            len(columns.get(name, ()))
+            for name in ("open", "high", "low", "close")
+        ),
+    )
+    precision_counts: Counter[str] = Counter()
+    column_precision_counts: dict[str, Counter[str]] = {
+        "open": Counter(),
+        "high": Counter(),
+        "low": Counter(),
+        "close": Counter(),
+    }
+    for index in range(sampled_count):
+        prices: list[float] = []
+        for column_name in ("open", "high", "low", "close"):
+            value = _finite_float(columns[column_name][index])
+            if value is None:
+                prices = []
+                break
+            prices.append(value)
+        if len(prices) != 4:
+            invalid_row_count += 1
+            continue
+        sampled_rows.append((prices[0], prices[1], prices[2], prices[3]))
+        for column_name, value in zip(
+            ("open", "high", "low", "close"),
+            prices,
+            strict=True,
+        ):
+            key = str(_decimal_places_from_float(value, profile))
+            precision_counts[key] += 1
+            column_precision_counts[column_name][key] += 1
+
+    payload = _m1_bar_distribution_from_rows(
+        sampled_rows,
+        row_count=row_count,
+        usable_row_count=len(sampled_rows),
+        invalid_row_count=invalid_row_count,
+        truncated=row_count > sampled_count,
+        profile=profile,
+    )
+    precision = cast(dict[str, JSONValue], payload["precision"])
+    precision["precision_source"] = precision_source
+    precision["decimal_place_counts"] = _counter_payload(precision_counts)
+    precision["column_decimal_place_counts"] = {
+        column: _counter_payload(counts)
+        for column, counts in column_precision_counts.items()
+    }
+    return payload
+
+
+def _m1_bar_distribution_from_rows(
+    rows: list[tuple[float, float, float, float]],
+    *,
+    row_count: int,
+    usable_row_count: int,
+    invalid_row_count: int,
+    truncated: bool,
+    profile: HistDataFingerprintProfile,
+) -> dict[str, JSONValue]:
+    open_values = [row[0] for row in rows]
+    high_values = [row[1] for row in rows]
+    low_values = [row[2] for row in rows]
+    close_values = [row[3] for row in rows]
+    range_ratios: list[float] = []
+    body_ratios: list[float] = []
+    upper_wick_ratios: list[float] = []
+    lower_wick_ratios: list[float] = []
+    for open_value, high_value, low_value, close_value in rows:
+        decimal_values = tuple(
+            Decimal(str(value))
+            for value in (open_value, high_value, low_value, close_value)
+        )
+        open_decimal, high_decimal, low_decimal, close_decimal = decimal_values
+        range_decimal = high_decimal - low_decimal
+        midpoint_decimal = (high_decimal + low_decimal) / Decimal("2")
+        if midpoint_decimal:
+            range_ratios.append(float(range_decimal / midpoint_decimal))
+        if range_decimal <= 0:
+            body_ratios.append(0.0)
+            upper_wick_ratios.append(0.0)
+            lower_wick_ratios.append(0.0)
+            continue
+        body_ratios.append(
+            float(abs(close_decimal - open_decimal) / range_decimal)
+        )
+        upper_wick_ratios.append(
+            float(
+                (high_decimal - max(open_decimal, close_decimal))
+                / range_decimal
+            )
+        )
+        lower_wick_ratios.append(
+            float(
+                (min(open_decimal, close_decimal) - low_decimal) / range_decimal
+            )
+        )
+    return {
+        "row_count": row_count,
+        "sampled_row_count": len(rows),
+        "usable_row_count": usable_row_count,
+        "invalid_row_count": invalid_row_count,
+        "truncated": truncated,
+        "price": {
+            "open": _numeric_summary(open_values, profile),
+            "high": _numeric_summary(high_values, profile),
+            "low": _numeric_summary(low_values, profile),
+            "close": _numeric_summary(close_values, profile),
+        },
+        "range_ratio": _numeric_summary(range_ratios, profile),
+        "ohlc_shape": {
+            "body_ratio": _numeric_summary(body_ratios, profile),
+            "upper_wick_ratio": _numeric_summary(
+                upper_wick_ratios,
+                profile,
+            ),
+            "lower_wick_ratio": _numeric_summary(
+                lower_wick_ratios,
+                profile,
+            ),
+        },
+        "precision": {
+            "precision_source": "unknown",
+            "decimal_place_counts": {},
+            "column_decimal_place_counts": {
+                "open": {},
+                "high": {},
+                "low": {},
+                "close": {},
+            },
+        },
+    }
+
+
+def _tick_distribution_from_frame(
+    frame: Any,
+    profile: HistDataFingerprintProfile,
+) -> dict[str, JSONValue]:
+    row_count = int(getattr(frame, "height", 0) or 0)
+    sample_limit = min(row_count, _profile_max_rows(profile))
+    bids = _frame_column_values(frame, "bid", sample_limit)
+    asks = _frame_column_values(frame, "ask", sample_limit)
+    return _tick_distribution_from_column_values(
+        bids,
+        asks,
+        row_count=row_count,
+        sample_limit=sample_limit,
+        profile=profile,
+    )
+
+
+def _tick_distribution_from_text(
+    text: str,
+    profile: HistDataFingerprintProfile,
+) -> dict[str, JSONValue]:
+    row_count = 0
+    invalid_row_count = 0
+    usable_row_count = 0
+    sample_limit = _profile_max_rows(profile)
+    bids: list[float] = []
+    asks: list[float] = []
+    reader = csv.reader(
+        text.splitlines(), delimiter=delimiter_for_timeframe(TICK)
+    )
+    for row in reader:
+        if not row or not any(cell.strip() for cell in row):
+            continue
+        row_count += 1
+        try:
+            parsed = normalize_ascii_row(TICK, row)
+        except (TypeError, ValueError, OverflowError):
+            invalid_row_count += 1
+            continue
+        bid = _finite_float(parsed[1])
+        ask = _finite_float(parsed[2])
+        if bid is None or ask is None:
+            invalid_row_count += 1
+            continue
+        usable_row_count += 1
+        if len(bids) >= sample_limit:
+            continue
+        bids.append(bid)
+        asks.append(ask)
+    return _tick_distribution_payload(
+        bids,
+        asks,
+        row_count=row_count,
+        sampled_row_count=len(bids),
+        usable_row_count=usable_row_count,
+        invalid_row_count=invalid_row_count,
+        truncated=usable_row_count > len(bids),
+        profile=profile,
+    )
+
+
+def _tick_distribution_from_column_values(
+    bids: list[Any],
+    asks: list[Any],
+    *,
+    row_count: int,
+    sample_limit: int,
+    profile: HistDataFingerprintProfile,
+) -> dict[str, JSONValue]:
+    sampled_bids: list[float] = []
+    sampled_asks: list[float] = []
+    invalid_row_count = 0
+    sampled_count = min(sample_limit, len(bids), len(asks))
+    for index in range(sampled_count):
+        bid = _finite_float(bids[index])
+        ask = _finite_float(asks[index])
+        if bid is None or ask is None:
+            invalid_row_count += 1
+            continue
+        sampled_bids.append(bid)
+        sampled_asks.append(ask)
+    return _tick_distribution_payload(
+        sampled_bids,
+        sampled_asks,
+        row_count=row_count,
+        sampled_row_count=len(sampled_bids),
+        usable_row_count=len(sampled_bids),
+        invalid_row_count=invalid_row_count,
+        truncated=row_count > sampled_count,
+        profile=profile,
+    )
+
+
+def _tick_distribution_payload(
+    bids: list[float],
+    asks: list[float],
+    *,
+    row_count: int,
+    sampled_row_count: int,
+    usable_row_count: int,
+    invalid_row_count: int,
+    truncated: bool,
+    profile: HistDataFingerprintProfile,
+) -> dict[str, JSONValue]:
+    spreads = [ask - bid for bid, ask in zip(bids, asks, strict=True)]
+    zero_spread_count = sum(1 for spread in spreads if spread == 0.0)
+    negative_spread_count = sum(1 for spread in spreads if spread < 0.0)
+    return {
+        "row_count": row_count,
+        "sampled_row_count": sampled_row_count,
+        "usable_row_count": usable_row_count,
+        "invalid_row_count": invalid_row_count,
+        "truncated": truncated,
+        "bid": _numeric_summary(bids, profile),
+        "ask": _numeric_summary(asks, profile),
+        "spread": _numeric_summary(spreads, profile),
+        "zero_spread_count": zero_spread_count,
+        "negative_spread_count": negative_spread_count,
+        "zero_spread_rate": _rate(
+            zero_spread_count, sampled_row_count, profile
+        ),
+        "negative_spread_rate": _rate(
+            negative_spread_count,
+            sampled_row_count,
+            profile,
+        ),
+    }
+
+
+def _numeric_summary(
+    values: Iterable[float],
+    profile: HistDataFingerprintProfile,
+) -> dict[str, JSONValue]:
+    finite_values = sorted(value for value in values if _is_finite(value))
+    count = len(finite_values)
+    if count == 0:
+        return {
+            "count": 0,
+            "min": None,
+            "max": None,
+            "mean": None,
+            "median": None,
+            "mad": None,
+            "quantiles": {
+                _quantile_label(quantile): None
+                for quantile in profile.quantiles
+            },
+        }
+    median = _quantile(finite_values, 0.5)
+    mad = _quantile(
+        sorted(abs(value - median) for value in finite_values),
+        0.5,
+    )
+    return {
+        "count": count,
+        "min": _rounded(finite_values[0], profile),
+        "max": _rounded(finite_values[-1], profile),
+        "mean": _rounded(sum(finite_values) / count, profile),
+        "median": _rounded(median, profile),
+        "mad": _rounded(mad, profile),
+        "quantiles": {
+            _quantile_label(quantile): _rounded(
+                _quantile(finite_values, quantile),
+                profile,
+            )
+            for quantile in profile.quantiles
+        },
+    }
+
+
+def _quantile(values: list[float], quantile: float) -> float:
+    if not values:
+        return math.nan
+    clipped = min(max(float(quantile), 0.0), 1.0)
+    index = (len(values) - 1) * clipped
+    lower = math.floor(index)
+    upper = math.ceil(index)
+    if lower == upper:
+        return values[lower]
+    lower_value = values[lower]
+    upper_value = values[upper]
+    return lower_value + (upper_value - lower_value) * (index - lower)
+
+
+def _quantile_label(quantile: float) -> str:
+    return str(float(quantile))
+
+
+def _rate(
+    numerator: int,
+    denominator: int,
+    profile: HistDataFingerprintProfile,
+) -> float | None:
+    if denominator <= 0:
+        return None
+    return _rounded(numerator / denominator, profile)
+
+
+def _rounded(
+    value: float,
+    profile: HistDataFingerprintProfile,
+) -> float:
+    digits = max(0, int(profile.rounding_digits))
+    try:
+        with localcontext() as context:
+            context.prec = max(28, digits + 20)
+            rounded_decimal = Decimal(str(float(value))).quantize(
+                Decimal(1).scaleb(-digits)
+            )
+        rounded = float(rounded_decimal)
+    except (InvalidOperation, ValueError, OverflowError):
+        rounded = round(float(value), digits)
+    return 0.0 if rounded == 0 else rounded
+
+
+def _finite_float(value: object) -> float | None:
+    try:
+        normalized = float(cast(Any, value))
+    except (TypeError, ValueError, OverflowError):
+        return None
+    if not _is_finite(normalized):
+        return None
+    return normalized
+
+
+def _is_finite(value: float) -> bool:
+    return math.isfinite(float(value))
+
+
+def _frame_column_values(
+    frame: Any,
+    column: str,
+    limit: int,
+) -> list[Any]:
+    try:
+        series = frame.get_column(column)
+    except (AttributeError, KeyError, TypeError, ValueError):
+        return []
+    try:
+        return cast(list[Any], series.head(limit).to_list())
+    except AttributeError:
+        return list(series)[:limit]
+
+
+def _profile_max_rows(profile: HistDataFingerprintProfile) -> int:
+    return max(1, int(profile.max_rows))
+
+
+def _decimal_places_from_text(value: str) -> int:
+    normalized = value.strip().lower()
+    mantissa = normalized.split("e", 1)[0]
+    if "." not in mantissa:
+        return 0
+    return len(mantissa.split(".", 1)[1])
+
+
+def _decimal_places_from_float(
+    value: float,
+    profile: HistDataFingerprintProfile,
+) -> int:
+    digits = max(0, int(profile.rounding_digits))
+    text = f"{value:.{digits}f}".rstrip("0").rstrip(".")
+    if "." not in text:
+        return 0
+    return len(text.split(".", 1)[1])
 
 
 def _cache_timestamp_at(frame: Any, row_index: int) -> int | None:

--- a/src/histdatacom/data_quality/fingerprints.py
+++ b/src/histdatacom/data_quality/fingerprints.py
@@ -912,10 +912,11 @@ def _m1_bar_distribution_from_frame(
         frame,
         ("open", "high", "low", "close"),
     )
-    columns = {
-        name: _frame_column_values(frame, name, sample_limit)
-        for name in ("open", "high", "low", "close")
-    }
+    columns = _frame_sampled_valid_column_values(
+        frame,
+        ("open", "high", "low", "close"),
+        sample_limit,
+    )
     return _m1_bar_distribution_from_column_values(
         columns,
         row_count=row_count,
@@ -1146,11 +1147,14 @@ def _tick_distribution_from_frame(
     row_count = int(getattr(frame, "height", 0) or 0)
     sample_limit = min(row_count, _profile_max_rows(profile))
     usable_row_count = _frame_numeric_usable_row_count(frame, ("bid", "ask"))
-    bids = _frame_column_values(frame, "bid", sample_limit)
-    asks = _frame_column_values(frame, "ask", sample_limit)
+    columns = _frame_sampled_valid_column_values(
+        frame,
+        ("bid", "ask"),
+        sample_limit,
+    )
     return _tick_distribution_from_column_values(
-        bids,
-        asks,
+        columns["bid"],
+        columns["ask"],
         row_count=row_count,
         usable_row_count=usable_row_count,
         sample_limit=sample_limit,
@@ -1384,6 +1388,75 @@ def _frame_column_values(
         return cast(list[Any], series.head(limit).to_list())
     except AttributeError:
         return list(series)[:limit]
+
+
+def _frame_sampled_valid_column_values(
+    frame: Any,
+    columns: tuple[str, ...],
+    limit: int,
+) -> dict[str, list[Any]]:
+    empty: dict[str, list[Any]] = {column: [] for column in columns}
+    if not columns or limit <= 0:
+        return empty
+    try:
+        import polars as pl
+        from polars.exceptions import PolarsError
+    except ImportError:
+        return _frame_sampled_valid_column_values_fallback(
+            frame, columns, limit
+        )
+
+    try:
+        expressions = [
+            pl.col(column).is_not_null() & pl.col(column).is_finite()
+            for column in columns
+        ]
+        sample = (
+            frame.select([pl.col(column) for column in columns])
+            .filter(pl.all_horizontal(*expressions))
+            .head(limit)
+        )
+        return {
+            column: cast(list[Any], sample.get_column(column).to_list())
+            for column in columns
+        }
+    except (AttributeError, TypeError, ValueError, PolarsError):
+        return _frame_sampled_valid_column_values_fallback(
+            frame, columns, limit
+        )
+
+
+def _frame_sampled_valid_column_values_fallback(
+    frame: Any,
+    columns: tuple[str, ...],
+    limit: int,
+) -> dict[str, list[Any]]:
+    sampled: dict[str, list[Any]] = {column: [] for column in columns}
+    row_count = int(getattr(frame, "height", 0) or 0)
+    if not columns or row_count <= 0 or limit <= 0:
+        return sampled
+    column_values = {
+        column: _frame_column_values(frame, column, row_count)
+        for column in columns
+    }
+    scanned_count = min(
+        row_count, *(len(values) for values in column_values.values())
+    )
+    for index in range(scanned_count):
+        row_values: dict[str, Any] = {}
+        for column in columns:
+            value = column_values[column][index]
+            if _finite_float(value) is None:
+                row_values = {}
+                break
+            row_values[column] = value
+        if not row_values:
+            continue
+        for column, value in row_values.items():
+            sampled[column].append(value)
+        if len(sampled[columns[0]]) >= limit:
+            break
+    return sampled
 
 
 def _frame_numeric_usable_row_count(

--- a/src/histdatacom/data_quality/remediation_audit.py
+++ b/src/histdatacom/data_quality/remediation_audit.py
@@ -8,7 +8,7 @@ from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass, field
 import json
 from pathlib import Path
-from typing import TypeVar
+from typing import TypeVar, cast
 
 from histdatacom.data_quality.contracts import (
     QualityReport,
@@ -168,7 +168,7 @@ def audit_remediation_catalog(
             )
             for aggregate in included_unmapped_known
         ],
-        "report_coverage": report_payloads,
+        "report_coverage": cast(JSONValue, report_payloads),
         "payload_limits": {
             "known_unmapped_codes": _payload_limit_metadata(
                 len(unmapped_known),
@@ -214,7 +214,7 @@ def audit_remediation_catalog_report_paths(
 ) -> dict[str, JSONValue]:
     """Audit the catalog with optional saved quality-report evidence."""
     reports = tuple(
-        (publish_safe_path(path), load_quality_report(path))
+        (publish_safe_path(str(path)), load_quality_report(path))
         for path in report_paths
     )
     return audit_remediation_catalog(

--- a/tests/unit/test_data_quality_fingerprints.py
+++ b/tests/unit/test_data_quality_fingerprints.py
@@ -364,10 +364,10 @@ def test_fingerprint_rule_prefers_fresh_sibling_cache(
     assert topology["cache_source"] == "sibling"
 
 
-def test_fingerprint_cache_distribution_counts_unsampled_invalid_rows(
+def test_fingerprint_cache_distribution_counts_full_rows_and_fills_sample(
     tmp_path: Path,
 ) -> None:
-    """Cache distributions should count all usable rows while sampling summaries."""
+    """Cache distributions should count all rows and fill samples from usable rows."""
     import polars as pl
 
     profile = HistDataFingerprintProfile(max_rows=1)
@@ -376,10 +376,10 @@ def test_fingerprint_cache_distribution_counts_unsampled_invalid_rows(
     m1_frame = pl.DataFrame(
         {
             "datetime": [1, 2, 3],
-            "open": [1.0, None, 1.2],
+            "open": [None, 1.1, 1.2],
             "high": [1.1, 1.2, 1.3],
             "low": [0.9, 1.0, 1.1],
-            "close": [1.05, 1.1, 1.25],
+            "close": [1.05, 1.15, 1.25],
             "vol": [0, 0, 0],
         },
         schema={
@@ -409,15 +409,17 @@ def test_fingerprint_cache_distribution_counts_unsampled_invalid_rows(
     assert m1_distribution["usable_row_count"] == 2
     assert m1_distribution["invalid_row_count"] == 1
     assert m1_distribution["truncated"] is True
-    assert _mapping(_mapping(m1_distribution["price"])["open"])["count"] == 1
+    open_summary = _mapping(_mapping(m1_distribution["price"])["open"])
+    assert open_summary["count"] == 1
+    assert open_summary["median"] == 1.1
 
     tick_cache_path = tmp_path / "tick-cache" / CACHE_FILENAME
     tick_cache_path.parent.mkdir(parents=True, exist_ok=True)
     tick_frame = pl.DataFrame(
         {
             "datetime": [1, 2, 3],
-            "bid": [1.0, 1.1, None],
-            "ask": [1.0001, 1.1002, 1.2],
+            "bid": [None, 1.1, 1.2],
+            "ask": [1.0001, 1.1002, 1.2003],
             "vol": [0, 0, 0],
         },
         schema={
@@ -447,7 +449,9 @@ def test_fingerprint_cache_distribution_counts_unsampled_invalid_rows(
     assert tick_distribution["usable_row_count"] == 2
     assert tick_distribution["invalid_row_count"] == 1
     assert tick_distribution["truncated"] is True
-    assert _mapping(tick_distribution["spread"])["count"] == 1
+    spread_summary = _mapping(tick_distribution["spread"])
+    assert spread_summary["count"] == 1
+    assert spread_summary["median"] == 0.0002
 
 
 def test_fingerprint_temporal_topology_reports_m1_duplicate_timestamp(

--- a/tests/unit/test_data_quality_fingerprints.py
+++ b/tests/unit/test_data_quality_fingerprints.py
@@ -364,6 +364,92 @@ def test_fingerprint_rule_prefers_fresh_sibling_cache(
     assert topology["cache_source"] == "sibling"
 
 
+def test_fingerprint_cache_distribution_counts_unsampled_invalid_rows(
+    tmp_path: Path,
+) -> None:
+    """Cache distributions should count all usable rows while sampling summaries."""
+    import polars as pl
+
+    profile = HistDataFingerprintProfile(max_rows=1)
+    m1_cache_path = tmp_path / "m1-cache" / CACHE_FILENAME
+    m1_cache_path.parent.mkdir(parents=True, exist_ok=True)
+    m1_frame = pl.DataFrame(
+        {
+            "datetime": [1, 2, 3],
+            "open": [1.0, None, 1.2],
+            "high": [1.1, 1.2, 1.3],
+            "low": [0.9, 1.0, 1.1],
+            "close": [1.05, 1.1, 1.25],
+            "vol": [0, 0, 0],
+        },
+        schema={
+            "datetime": pl.Int64,
+            "open": pl.Float64,
+            "high": pl.Float64,
+            "low": pl.Float64,
+            "close": pl.Float64,
+            "vol": pl.Int32,
+        },
+    )
+    write_polars_cache(m1_frame, m1_cache_path)
+    m1_target = QualityTarget(
+        path=str(m1_cache_path),
+        kind=QualityTargetKind.CACHE,
+        data_format="ascii",
+        timeframe="M1",
+        symbol="EURUSD",
+        period="201202",
+    )
+
+    m1_payload = _fingerprint_payload(_fingerprint_finding(m1_target, profile))
+    m1_distribution = _mapping(m1_payload["m1_bar_distribution"])
+
+    assert m1_distribution["row_count"] == 3
+    assert m1_distribution["sampled_row_count"] == 1
+    assert m1_distribution["usable_row_count"] == 2
+    assert m1_distribution["invalid_row_count"] == 1
+    assert m1_distribution["truncated"] is True
+    assert _mapping(_mapping(m1_distribution["price"])["open"])["count"] == 1
+
+    tick_cache_path = tmp_path / "tick-cache" / CACHE_FILENAME
+    tick_cache_path.parent.mkdir(parents=True, exist_ok=True)
+    tick_frame = pl.DataFrame(
+        {
+            "datetime": [1, 2, 3],
+            "bid": [1.0, 1.1, None],
+            "ask": [1.0001, 1.1002, 1.2],
+            "vol": [0, 0, 0],
+        },
+        schema={
+            "datetime": pl.Int64,
+            "bid": pl.Float64,
+            "ask": pl.Float64,
+            "vol": pl.Int32,
+        },
+    )
+    write_polars_cache(tick_frame, tick_cache_path)
+    tick_target = QualityTarget(
+        path=str(tick_cache_path),
+        kind=QualityTargetKind.CACHE,
+        data_format="ascii",
+        timeframe="T",
+        symbol="EURUSD",
+        period="201202",
+    )
+
+    tick_payload = _fingerprint_payload(
+        _fingerprint_finding(tick_target, profile)
+    )
+    tick_distribution = _mapping(tick_payload["tick_distribution"])
+
+    assert tick_distribution["row_count"] == 3
+    assert tick_distribution["sampled_row_count"] == 1
+    assert tick_distribution["usable_row_count"] == 2
+    assert tick_distribution["invalid_row_count"] == 1
+    assert tick_distribution["truncated"] is True
+    assert _mapping(tick_distribution["spread"])["count"] == 1
+
+
 def test_fingerprint_temporal_topology_reports_m1_duplicate_timestamp(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/test_data_quality_fingerprints.py
+++ b/tests/unit/test_data_quality_fingerprints.py
@@ -23,6 +23,7 @@ from histdatacom.data_quality import (
     TIME_SERIES_FINGERPRINT_TOPOLOGY_ATTENTION_SCHEMA_VERSION,
     TIME_SERIES_FINGERPRINT_TOPOLOGY_SUMMARY_METADATA_KEY,
     TIME_SERIES_FINGERPRINT_TOPOLOGY_SUMMARY_SCHEMA_VERSION,
+    HistDataFingerprintProfile,
     HistDataSeriesFingerprintRule,
     QualityFinding,
     QualitySeverity,
@@ -109,6 +110,35 @@ def test_fingerprint_rule_emits_m1_csv_payload(tmp_path: Path) -> None:
     assert topology["computed_from"] == "text_scan"
     assert topology["timestamp_projection"] == "text_scan"
     assert topology["cache_source"] is None
+    distribution = _mapping(payload["m1_bar_distribution"])
+    assert distribution["row_count"] == 3
+    assert distribution["sampled_row_count"] == 3
+    assert distribution["usable_row_count"] == 3
+    assert distribution["invalid_row_count"] == 0
+    assert distribution["truncated"] is False
+    prices = _mapping(distribution["price"])
+    open_summary = _mapping(prices["open"])
+    assert open_summary["count"] == 3
+    assert open_summary["min"] == 1.30652
+    assert open_summary["max"] == 1.3066
+    assert open_summary["mean"] == 1.306563333333
+    assert open_summary["median"] == 1.30657
+    assert _mapping(open_summary["quantiles"])["0.5"] == 1.30657
+    shape = _mapping(distribution["ohlc_shape"])
+    body_summary = _mapping(shape["body_ratio"])
+    assert body_summary["count"] == 3
+    assert body_summary["min"] == 0.1
+    assert body_summary["median"] == 1.0
+    range_ratio = _mapping(distribution["range_ratio"])
+    assert range_ratio["count"] == 3
+    assert range_ratio["median"] == 0.000030615213
+    assert _mapping(distribution["precision"])["precision_source"] == "text"
+    assert _mapping(distribution["precision"])["decimal_place_counts"] == {
+        "6": 12,
+    }
+    assert _mapping(
+        _mapping(distribution["precision"])["column_decimal_place_counts"]
+    )["open"] == {"6": 3}
     assert _mapping(payload["source"])["kind"] == "csv_text"
 
 
@@ -126,7 +156,121 @@ def test_fingerprint_rule_emits_tick_csv_payload(tmp_path: Path) -> None:
         "end_timestamp_utc_ms": batch.summary.end,
         "duration_ms": 11_330,
     }
+    distribution = _mapping(payload["tick_distribution"])
+    assert distribution["row_count"] == 3
+    assert distribution["sampled_row_count"] == 3
+    assert distribution["usable_row_count"] == 3
+    assert distribution["invalid_row_count"] == 0
+    assert distribution["truncated"] is False
+    spread_summary = _mapping(distribution["spread"])
+    assert spread_summary["count"] == 3
+    assert spread_summary["min"] == 0.00017
+    assert spread_summary["max"] == 0.00017
+    assert spread_summary["median"] == 0.00017
+    assert _mapping(spread_summary["quantiles"])["0.5"] == 0.00017
+    assert distribution["zero_spread_count"] == 0
+    assert distribution["negative_spread_count"] == 0
+    assert distribution["zero_spread_rate"] == 0.0
+    assert distribution["negative_spread_rate"] == 0.0
     assert _mapping(payload["source"])["kind"] == "csv_text"
+
+
+def test_fingerprint_tick_distribution_counts_zero_and_negative_spreads(
+    tmp_path: Path,
+) -> None:
+    """Tick fingerprints should expose spread-defect rates descriptively."""
+    case = HistDataAsciiCase(
+        name="tick_spread_mix",
+        timeframe=TICK,
+        filename="DAT_ASCII_EURUSD_T_201202_SPREAD_MIX.csv",
+        rows=(
+            "20120201 000003660,1.000000,1.000000,0",
+            "20120201 000003973,1.000200,1.000100,0",
+            "20120201 000004990,1.000000,1.000300,0",
+        ),
+    )
+    target = _discovered_target(write_ascii_case(tmp_path, case))
+    payload = _fingerprint_payload(_fingerprint_finding(target))
+    distribution = _mapping(payload["tick_distribution"])
+
+    assert distribution["usable_row_count"] == 3
+    assert distribution["zero_spread_count"] == 1
+    assert distribution["negative_spread_count"] == 1
+    assert distribution["zero_spread_rate"] == 0.333333333333
+    assert distribution["negative_spread_rate"] == 0.333333333333
+    spread_summary = _mapping(distribution["spread"])
+    assert spread_summary["min"] == -0.0001
+    assert spread_summary["max"] == 0.0003
+
+
+def test_fingerprint_distribution_handles_invalid_partial_and_empty_m1_rows(
+    tmp_path: Path,
+) -> None:
+    """Distribution summaries should be bounded even for sparse bad input."""
+    invalid_target = _discovered_target(
+        write_ascii_case(tmp_path / "invalid", case_by_name("m1_bad_numeric"))
+    )
+    invalid_payload = _fingerprint_payload(_fingerprint_finding(invalid_target))
+    invalid_distribution = _mapping(invalid_payload["m1_bar_distribution"])
+
+    assert invalid_distribution["row_count"] == 2
+    assert invalid_distribution["sampled_row_count"] == 1
+    assert invalid_distribution["usable_row_count"] == 1
+    assert invalid_distribution["invalid_row_count"] == 1
+    close_summary = _mapping(_mapping(invalid_distribution["price"])["close"])
+    assert close_summary["count"] == 1
+    assert close_summary["median"] == 1.30656
+
+    partial_target = _discovered_target(
+        write_ascii_case(tmp_path / "partial", case_by_name("m1_malformed_row"))
+    )
+    partial_payload = _fingerprint_payload(_fingerprint_finding(partial_target))
+    partial_distribution = _mapping(partial_payload["m1_bar_distribution"])
+
+    assert partial_distribution["row_count"] == 2
+    assert partial_distribution["sampled_row_count"] == 1
+    assert partial_distribution["usable_row_count"] == 1
+    assert partial_distribution["invalid_row_count"] == 1
+
+    empty_target = _discovered_target(
+        write_ascii_case(tmp_path / "empty", case_by_name("m1_empty_file"))
+    )
+    empty_payload = _fingerprint_payload(_fingerprint_finding(empty_target))
+    empty_distribution = _mapping(empty_payload["m1_bar_distribution"])
+    empty_summary = _mapping(_mapping(empty_distribution["price"])["open"])
+
+    assert empty_distribution["row_count"] == 0
+    assert empty_distribution["sampled_row_count"] == 0
+    assert empty_distribution["usable_row_count"] == 0
+    assert empty_distribution["invalid_row_count"] == 0
+    assert empty_summary["count"] == 0
+    assert empty_summary["median"] is None
+
+
+def test_fingerprint_distribution_uses_profile_quantiles_and_rounding(
+    tmp_path: Path,
+) -> None:
+    """Fingerprint profile knobs should shape distribution payloads."""
+    target = _discovered_target(write_ascii_case(tmp_path, CLEAN_M1_CASE))
+    profile = HistDataFingerprintProfile(
+        quantiles=(0.0, 0.5, 1.0),
+        max_rows=2,
+        rounding_digits=5,
+    )
+    payload = _fingerprint_payload(_fingerprint_finding(target, profile))
+    distribution = _mapping(payload["m1_bar_distribution"])
+    open_summary = _mapping(_mapping(distribution["price"])["open"])
+
+    assert distribution["row_count"] == 3
+    assert distribution["sampled_row_count"] == 2
+    assert distribution["usable_row_count"] == 3
+    assert distribution["truncated"] is True
+    assert open_summary["mean"] == 1.30658
+    assert _mapping(open_summary["quantiles"]) == {
+        "0.0": 1.30657,
+        "0.5": 1.30658,
+        "1.0": 1.3066,
+    }
 
 
 def test_fingerprint_rule_emits_zip_member_payload(tmp_path: Path) -> None:
@@ -176,6 +320,12 @@ def test_fingerprint_rule_prefers_direct_cache_payload(
         "end_timestamp_utc_ms": batch.summary.end,
         "duration_ms": 120_000,
     }
+    distribution = _mapping(payload["m1_bar_distribution"])
+    assert distribution["row_count"] == 3
+    assert _mapping(_mapping(distribution["price"])["close"])["count"] == 3
+    assert _mapping(distribution["precision"])["precision_source"] == (
+        "cache_float"
+    )
     topology = _mapping(payload["temporal_topology"])
     assert topology["computed_from"] == "direct_cache"
     assert topology["timestamp_projection"] == "polars_cache"
@@ -207,6 +357,7 @@ def test_fingerprint_rule_prefers_fresh_sibling_cache(
         "path": ".data",
     }
     assert _mapping(payload["coverage"])["row_count"] == 3
+    assert _mapping(payload["m1_bar_distribution"])["row_count"] == 3
     topology = _mapping(payload["temporal_topology"])
     assert topology["computed_from"] == "fresh_sibling_cache"
     assert topology["timestamp_projection"] == "polars_cache"
@@ -923,8 +1074,13 @@ def _discovered_target(path: Path) -> QualityTarget:
     return target
 
 
-def _fingerprint_finding(target: QualityTarget) -> QualityFinding:
-    rule = HistDataSeriesFingerprintRule()
+def _fingerprint_finding(
+    target: QualityTarget,
+    profile: HistDataFingerprintProfile | None = None,
+) -> QualityFinding:
+    rule = HistDataSeriesFingerprintRule(
+        profile=profile or HistDataFingerprintProfile()
+    )
     findings = tuple(rule.evaluate(target))
     assert len(findings) == 1
     finding = findings[0]


### PR DESCRIPTION
## Summary
- Adds `m1_bar_distribution` to `fingerprint.series` for M1 targets, including bounded OHLC price summaries, range ratio, body/wick shape, and decimal precision counts.
- Adds `tick_distribution` for tick targets, including bid/ask/spread summaries plus zero- and negative-spread counts/rates.
- Uses fingerprint profile quantiles, max-row sampling, and rounding; keeps the cache-first path with CSV/ZIP text fallback.
- Fixes the closure-audit seam where cache-backed distributions counted only sampled usable/invalid rows; cache targets now count full-frame usable/invalid rows while keeping metric summaries bounded.
- Fixes the follow-up review seam where cache-backed M1/tick sampling limited to the first raw rows before filtering invalid rows; cache samples now fill from the first usable rows.
- Includes a small type-only remediation audit cleanup found while running the full pre-commit mypy gate.

## Validation
- `uv run --no-sync pytest tests/unit/test_data_quality_fingerprints.py` (22 passed)
- `uv run --no-sync pytest tests/unit/test_data_quality_reporting.py tests/unit/test_data_quality_report_goldens.py tests/unit/test_data_quality_profiles.py` (53 passed)
- `uv run --no-sync pytest` (1239 passed)
- `uv run --no-sync pre-commit run --all-files` (passed)
- Commit hook passed, including coverage-backed full `pytest` and Commitizen checks.
- Pre-push hook passed, including coverage-backed full `pytest` and Commitizen branch checks.

Closes #325
