### PR TITLE
[codex] render dependence readiness summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -1003,9 +1003,12 @@ Quality JSON reports and CLI summaries also include a bounded
 present. Use that report-level summary to scan whether return or microstructure
 dynamics are valid, limited, skipped, or unavailable; which topology limitations
 affect sequence interpretation; and the compact return, jump, flatline, spread,
-stale quote, burst, and one-sided movement facts. Use the raw
-`time_series_fingerprint` payload when downstream tooling needs the complete
-fingerprint sections or full quantile maps.
+stale quote, burst, and one-sided movement facts. The same readiness summary
+also includes bounded dependence status, ACF basis, configured lag coverage,
+computed/skipped lag counts, skipped-lag reason counts, and per-series sample
+counts. Use the raw `time_series_fingerprint` payload when downstream tooling
+needs the complete fingerprint sections, full quantile maps, or full ACF lag
+maps.
 
 Discover the active fingerprint contract without scanning target data:
 

--- a/src/histdatacom/data_quality/fingerprints.py
+++ b/src/histdatacom/data_quality/fingerprints.py
@@ -130,6 +130,7 @@ DEFAULT_FINGERPRINT_TOPOLOGY_ATTENTION_LIMIT = 32
 DEFAULT_FINGERPRINT_DISTRIBUTION_SUMMARY_LIMIT = 128
 DEFAULT_FINGERPRINT_DISTRIBUTION_ATTENTION_LIMIT = 32
 DEFAULT_FINGERPRINT_READINESS_SUMMARY_LIMIT = 16
+DEFAULT_FINGERPRINT_READINESS_LAG_LIMIT = 16
 DEFAULT_FINGERPRINT_DISTRIBUTION_INVALID_ROW_MIN_COUNT = 1
 DEFAULT_FINGERPRINT_DISTRIBUTION_INVALID_ROW_MIN_RATE = 0.0
 DEFAULT_FINGERPRINT_DISTRIBUTION_ZERO_SPREAD_MIN_COUNT = 1
@@ -688,6 +689,13 @@ def series_fingerprint_readiness_summary(
         dynamics_status_counts[section] = _counter_payload(status_counts)
         dynamics_reason_counts[section] = _counter_payload(reason_counts)
 
+    dependence_status_counts: Counter[str] = Counter()
+    dependence_reason_counts: Counter[str] = Counter()
+    dependence_acf_basis_counts: Counter[str] = Counter()
+    dependence_limitation_counts: Counter[str] = Counter()
+    dependence_skipped_lag_reason_counts: Counter[str] = Counter()
+    dependence_computed_lag_count = 0
+    dependence_skipped_lag_count = 0
     topology_limitation_counts: Counter[str] = Counter()
     dynamics_limitation_counts: Counter[str] = Counter()
     row_order_counts: Counter[str] = Counter()
@@ -725,6 +733,29 @@ def series_fingerprint_readiness_summary(
                 computed_from_counts[computed_from] += 1
             if cache_source:
                 cache_source_counts[cache_source] += 1
+        dependence = _payload_mapping(item.get("dependence"))
+        dependence_status_counts[_summary_key(dependence.get("status"))] += 1
+        dependence_reason = _optional_summary_key(dependence.get("reason"))
+        if dependence_reason:
+            dependence_reason_counts[dependence_reason] += 1
+        acf_basis = _summary_key(dependence.get("acf_basis"))
+        if acf_basis != "unknown":
+            dependence_acf_basis_counts[acf_basis] += 1
+        dependence_limitation_counts.update(
+            _summary_key(value)
+            for value in _string_list(dependence.get("limitations"))
+        )
+        dependence_skipped_lag_reason_counts.update(
+            _counter_from_mapping(
+                _payload_mapping(dependence.get("skipped_lag_reason_counts"))
+            )
+        )
+        dependence_computed_lag_count += _int_payload(
+            dependence.get("computed_lag_count")
+        )
+        dependence_skipped_lag_count += _int_payload(
+            dependence.get("skipped_lag_count")
+        )
 
     profile_complete_count = sum(
         1
@@ -766,6 +797,19 @@ def series_fingerprint_readiness_summary(
         "section_status_counts": section_status_counts,
         "dynamics_status_counts": dynamics_status_counts,
         "dynamics_reason_counts": dynamics_reason_counts,
+        "dependence_status_counts": _counter_payload(dependence_status_counts),
+        "dependence_reason_counts": _counter_payload(dependence_reason_counts),
+        "dependence_acf_basis_counts": _counter_payload(
+            dependence_acf_basis_counts
+        ),
+        "dependence_limitation_counts": _counter_payload(
+            dependence_limitation_counts
+        ),
+        "dependence_skipped_lag_reason_counts": _counter_payload(
+            dependence_skipped_lag_reason_counts
+        ),
+        "dependence_computed_lag_count": dependence_computed_lag_count,
+        "dependence_skipped_lag_count": dependence_skipped_lag_count,
         "topology_limitation_counts": _counter_payload(
             topology_limitation_counts
         ),
@@ -870,6 +914,12 @@ def _fingerprint_readiness_target_summary(
         )
     )
     topology = _payload_mapping(payload.get("temporal_topology"))
+    dependence_readiness = _fingerprint_readiness_dependence_summary(
+        finding,
+        payload,
+        section_statuses=section_statuses,
+        skipped_sections=skipped_sections,
+    )
 
     return {
         "target_axis": target_axis,
@@ -909,6 +959,7 @@ def _fingerprint_readiness_target_summary(
                 microstructure_readiness,
             )
         ),
+        "dependence": dependence_readiness,
     }
 
 
@@ -1155,6 +1206,147 @@ def _fingerprint_readiness_microstructure_summary(
     return summary
 
 
+def _fingerprint_readiness_dependence_summary(
+    finding: QualityFinding,
+    payload: Mapping[str, JSONValue],
+    *,
+    section_statuses: Mapping[str, JSONValue],
+    skipped_sections: Mapping[str, JSONValue],
+) -> dict[str, JSONValue]:
+    dependence = _payload_mapping(payload.get("dependence"))
+    if not dependence:
+        status = _summary_key(section_statuses.get("dependence") or "skipped")
+        if status not in {"skipped", "unavailable"}:
+            status = "skipped"
+        skipped = _payload_mapping(skipped_sections.get("dependence"))
+        reason = _optional_summary_key(skipped.get("reason"))
+        if reason is None:
+            reason = _fingerprint_section_skip_reason(
+                "dependence",
+                payload,
+                target=finding.target,
+            )
+        return _empty_dependence_readiness(status=status, reason=reason)
+
+    series = {
+        name: _compact_acf_series_summary(value)
+        for name, value in sorted(dependence.items())
+        if name.endswith("_acf") and isinstance(value, Mapping)
+    }
+    skipped_reason_counts: Counter[str] = Counter()
+    for summary in series.values():
+        skipped_reason_counts.update(
+            _counter_from_mapping(
+                _payload_mapping(summary.get("skipped_lag_reason_counts"))
+            )
+        )
+    computed_lag_count = _int_payload(dependence.get("computed_lag_count"))
+    if computed_lag_count <= 0:
+        computed_lag_count = sum(
+            _int_payload(summary.get("computed_lag_count"))
+            for summary in series.values()
+        )
+    skipped_lag_count = _int_payload(dependence.get("skipped_lag_count"))
+    if skipped_lag_count <= 0:
+        skipped_lag_count = sum(
+            _int_payload(summary.get("skipped_lag_count"))
+            for summary in series.values()
+        )
+    lags = _int_sequence_payload(dependence.get("lags"))
+    included_lags = lags[:DEFAULT_FINGERPRINT_READINESS_LAG_LIMIT]
+    omitted_lag_count = max(0, len(lags) - len(included_lags))
+    result: dict[str, JSONValue] = {
+        "status": _dependence_section_status(dependence),
+        "reason": _optional_summary_key(dependence.get("reason")),
+        "basis": _summary_key(dependence.get("basis")),
+        "acf_basis": _summary_key(dependence.get("acf_basis")),
+        "row_order": _summary_key(dependence.get("row_order")),
+        "computed_from": _summary_key(dependence.get("computed_from")),
+        "cache_source": _optional_summary_key(dependence.get("cache_source")),
+        "regular_grid": dependence.get("regular_grid") is True,
+        "limitations": _string_list(dependence.get("limitations")),
+        "row_count": _int_payload(dependence.get("row_count")),
+        "sampled_row_count": _int_payload(dependence.get("sampled_row_count")),
+        "usable_row_count": _int_payload(dependence.get("usable_row_count")),
+        "invalid_row_count": _int_payload(dependence.get("invalid_row_count")),
+        "partial_row_count": _int_payload(dependence.get("partial_row_count")),
+        "truncated": dependence.get("truncated") is True,
+        "lag_count": len(lags),
+        "lags": list(included_lags),
+        "included_lag_count": len(included_lags),
+        "omitted_lag_count": omitted_lag_count,
+        "lags_truncated": omitted_lag_count > 0,
+        "computed_lag_count": computed_lag_count,
+        "skipped_lag_count": skipped_lag_count,
+        "skipped_lag_reason_counts": _counter_payload(skipped_reason_counts),
+        "series_count": len(series),
+    }
+    result["series"] = cast(JSONValue, series)
+    return result
+
+
+def _empty_dependence_readiness(
+    *,
+    status: str,
+    reason: str | None,
+) -> dict[str, JSONValue]:
+    return {
+        "status": status,
+        "reason": reason,
+        "basis": "unknown",
+        "acf_basis": "unknown",
+        "row_order": "unknown",
+        "computed_from": "unknown",
+        "cache_source": None,
+        "regular_grid": False,
+        "limitations": [],
+        "row_count": 0,
+        "sampled_row_count": 0,
+        "usable_row_count": 0,
+        "invalid_row_count": 0,
+        "partial_row_count": 0,
+        "truncated": False,
+        "lag_count": 0,
+        "lags": [],
+        "included_lag_count": 0,
+        "omitted_lag_count": 0,
+        "lags_truncated": False,
+        "computed_lag_count": 0,
+        "skipped_lag_count": 0,
+        "skipped_lag_reason_counts": {},
+        "series_count": 0,
+        "series": {},
+    }
+
+
+def _compact_acf_series_summary(value: JSONValue) -> dict[str, JSONValue]:
+    acf = _payload_mapping(value)
+    skipped_reason_counts = _acf_skipped_lag_reason_counts(acf)
+    computed_lag_count = _int_payload(acf.get("computed_lag_count"))
+    if computed_lag_count <= 0:
+        computed_lag_count = len(_payload_mapping(acf.get("lag_acf")))
+    skipped_lag_count = _int_payload(acf.get("skipped_lag_count"))
+    if skipped_lag_count <= 0:
+        skipped_lag_count = sum(skipped_reason_counts.values())
+    return {
+        "sample_count": _int_payload(acf.get("sample_count")),
+        "computed_lag_count": computed_lag_count,
+        "skipped_lag_count": skipped_lag_count,
+        "skipped_lag_reason_counts": _counter_payload(skipped_reason_counts),
+    }
+
+
+def _acf_skipped_lag_reason_counts(
+    acf: Mapping[str, JSONValue],
+) -> Counter[str]:
+    counts: Counter[str] = Counter()
+    for skipped in _payload_mapping(acf.get("skipped_lags")).values():
+        reason = _optional_summary_key(_payload_mapping(skipped).get("reason"))
+        if reason:
+            counts[reason] += 1
+    return counts
+
+
 def _compact_numeric_summary(value: JSONValue) -> dict[str, JSONValue]:
     numeric = _payload_mapping(value)
     if not numeric:
@@ -1225,10 +1417,17 @@ def _fingerprint_readiness_target_sort_key(
     target: Mapping[str, JSONValue],
 ) -> tuple[object, ...]:
     axis = _payload_mapping(target.get("target_axis"))
-    return (
+    dependence = _payload_mapping(target.get("dependence"))
+    readiness_rank = min(
         _fingerprint_readiness_status_rank(
             _summary_key(target.get("applicable_dynamics_status"))
         ),
+        _fingerprint_readiness_status_rank(
+            _summary_key(dependence.get("status"))
+        ),
+    )
+    return (
+        readiness_rank,
         _summary_key(axis.get("data_format")),
         _summary_key(axis.get("timeframe")),
         _summary_key(axis.get("symbol")),
@@ -2213,6 +2412,29 @@ def _summary_key(value: object) -> str:
 
 def _counter_payload(counter: Counter[str]) -> dict[str, JSONValue]:
     return {key: counter[key] for key in sorted(counter)}
+
+
+def _counter_from_mapping(mapping: Mapping[str, JSONValue]) -> Counter[str]:
+    counter: Counter[str] = Counter()
+    for key, value in mapping.items():
+        count = _int_payload(value)
+        if count > 0:
+            counter[_summary_key(key)] += count
+    return counter
+
+
+def _int_sequence_payload(value: JSONValue) -> tuple[int, ...]:
+    if not isinstance(value, (list, tuple)):
+        return ()
+    parsed: list[int] = []
+    for item in value:
+        if isinstance(item, bool):
+            continue
+        try:
+            parsed.append(int(item))  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            continue
+    return tuple(parsed)
 
 
 def _has_parsed_non_empty_coverage(

--- a/src/histdatacom/data_quality/reporting.py
+++ b/src/histdatacom/data_quality/reporting.py
@@ -2069,9 +2069,37 @@ def format_fingerprint_readiness_summary_lines(
             if reasons:
                 line += f" reasons: {reasons}"
             lines.append(line)
+    dependence_counts = _format_count_metadata(
+        summary.get("dependence_status_counts")
+    )
+    if dependence_counts:
+        dependence_line = f"- dependence: {dependence_counts}"
+        dependence_reasons = _format_count_metadata(
+            summary.get("dependence_reason_counts")
+        )
+        if dependence_reasons:
+            dependence_line += f" reasons: {dependence_reasons}"
+        skipped_reasons = _format_count_metadata(
+            summary.get("dependence_skipped_lag_reason_counts")
+        )
+        if skipped_reasons:
+            dependence_line += f" skipped-lag reasons: {skipped_reasons}"
+        acf_basis = _format_count_metadata(
+            summary.get("dependence_acf_basis_counts")
+        )
+        if acf_basis:
+            dependence_line += f" acf_basis: {acf_basis}"
+        dependence_line += (
+            " computed_lags="
+            f"{_int_metadata(summary, 'dependence_computed_lag_count')} "
+            "skipped_lags="
+            f"{_int_metadata(summary, 'dependence_skipped_lag_count')}"
+        )
+        lines.append(dependence_line)
     count_lines = (
         ("topology limitations", "topology_limitation_counts"),
         ("dynamics limitations", "dynamics_limitation_counts"),
+        ("dependence limitations", "dependence_limitation_counts"),
         ("row order", "row_order_counts"),
         ("computed from", "computed_from_counts"),
         ("cache sources", "cache_source_counts"),
@@ -2126,6 +2154,10 @@ def _format_fingerprint_readiness_target_line(
     cache_text = f", cache={cache_source}" if cache_source else ""
     details = _format_fingerprint_readiness_dynamics_details(section, dynamics)
     details_text = f", {details}" if details else ""
+    dependence_details = _format_fingerprint_readiness_dependence_details(
+        _mapping_payload(summary.get("dependence"))
+    )
+    dependence_text = f", {dependence_details}" if dependence_details else ""
     return (
         f"{_string_metadata(axis, 'data_format')} "
         f"{_string_metadata(axis, 'symbol')} "
@@ -2147,6 +2179,7 @@ def _format_fingerprint_readiness_target_line(
         f"truncated={_bool_text(dynamics.get('truncated'))}, "
         f"limitations={limitation_text}"
         f"{details_text}"
+        f"{dependence_text}"
     )
 
 
@@ -2220,6 +2253,59 @@ def _format_fingerprint_readiness_dynamics_details(
     return ""
 
 
+def _format_fingerprint_readiness_dependence_details(
+    dependence: Mapping[str, JSONValue],
+) -> str:
+    if not dependence:
+        return ""
+    status = _string_metadata(dependence, "status")
+    reason = _optional_string_metadata(dependence, "reason")
+    reason_text = f" reason={reason}" if reason else ""
+    skipped_reasons = _format_count_metadata(
+        dependence.get("skipped_lag_reason_counts")
+    )
+    skipped_reason_text = (
+        f" skipped_reasons={skipped_reasons}" if skipped_reasons else ""
+    )
+    series = _format_dependence_series_metadata(dependence.get("series"))
+    series_text = f" series={series}" if series else ""
+    return (
+        f"dependence={status}{reason_text} "
+        f"acf_basis={_string_metadata(dependence, 'acf_basis')} "
+        f"lags={_format_lag_metadata(dependence)} "
+        "computed_lags="
+        f"{_int_metadata(dependence, 'computed_lag_count')} "
+        "skipped_lags="
+        f"{_int_metadata(dependence, 'skipped_lag_count')}"
+        f"{skipped_reason_text}"
+        f"{series_text}"
+    )
+
+
+def _format_lag_metadata(dependence: Mapping[str, JSONValue]) -> str:
+    lags = _int_list_metadata(dependence.get("lags"))
+    omitted = _int_metadata(dependence, "omitted_lag_count")
+    lag_text = "[" + ",".join(str(lag) for lag in lags) + "]"
+    if omitted:
+        lag_text += f"+{omitted}"
+    return lag_text
+
+
+def _format_dependence_series_metadata(value: JSONValue) -> str:
+    series = _mapping_payload(value)
+    parts: list[str] = []
+    for name in sorted(series):
+        summary = _mapping_payload(series[name])
+        if not summary:
+            continue
+        parts.append(
+            f"{name}:samples={_int_metadata(summary, 'sample_count')}/"
+            f"computed={_int_metadata(summary, 'computed_lag_count')}/"
+            f"skipped={_int_metadata(summary, 'skipped_lag_count')}"
+        )
+    return ";".join(parts)
+
+
 def _count_metadata(value: JSONValue, key: str) -> int:
     if not isinstance(value, Mapping):
         return 0
@@ -2274,6 +2360,20 @@ def _string_list_metadata(value: object) -> list[str]:
     if not isinstance(value, list):
         return []
     return [str(item).strip() for item in value if str(item).strip()]
+
+
+def _int_list_metadata(value: object) -> list[int]:
+    if not isinstance(value, list):
+        return []
+    parsed: list[int] = []
+    for item in value:
+        if isinstance(item, bool):
+            continue
+        try:
+            parsed.append(int(item))  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            continue
+    return parsed
 
 
 def _list_metadata(value: object) -> list[Mapping[str, JSONValue]]:

--- a/tests/fixtures/data_quality_reports/fingerprint_bounded_payload.json
+++ b/tests/fixtures/data_quality_reports/fingerprint_bounded_payload.json
@@ -142,6 +142,17 @@
     },
     "cache_source_counts": {},
     "computed_from_counts": {},
+    "dependence_acf_basis_counts": {},
+    "dependence_computed_lag_count": 0,
+    "dependence_limitation_counts": {},
+    "dependence_reason_counts": {
+      "not_emitted": 1
+    },
+    "dependence_skipped_lag_count": 0,
+    "dependence_skipped_lag_reason_counts": {},
+    "dependence_status_counts": {
+      "skipped": 1
+    },
     "dynamics_limitation_counts": {},
     "dynamics_reason_counts": {
       "microstructure_dynamics": {
@@ -195,6 +206,33 @@
         "applicable_dynamics_reason": "not_emitted",
         "applicable_dynamics_section": "return_dynamics",
         "applicable_dynamics_status": "skipped",
+        "dependence": {
+          "acf_basis": "unknown",
+          "basis": "unknown",
+          "cache_source": null,
+          "computed_from": "unknown",
+          "computed_lag_count": 0,
+          "included_lag_count": 0,
+          "invalid_row_count": 0,
+          "lag_count": 0,
+          "lags": [],
+          "lags_truncated": false,
+          "limitations": [],
+          "omitted_lag_count": 0,
+          "partial_row_count": 0,
+          "reason": "not_emitted",
+          "regular_grid": false,
+          "row_count": 0,
+          "row_order": "unknown",
+          "sampled_row_count": 0,
+          "series": {},
+          "series_count": 0,
+          "skipped_lag_count": 0,
+          "skipped_lag_reason_counts": {},
+          "status": "skipped",
+          "truncated": false,
+          "usable_row_count": 0
+        },
         "microstructure_dynamics": {
           "basis": "unknown",
           "cache_source": null,

--- a/tests/fixtures/data_quality_reports/fingerprint_report.json
+++ b/tests/fixtures/data_quality_reports/fingerprint_report.json
@@ -240,6 +240,17 @@
       },
       "cache_source_counts": {},
       "computed_from_counts": {},
+      "dependence_acf_basis_counts": {},
+      "dependence_computed_lag_count": 0,
+      "dependence_limitation_counts": {},
+      "dependence_reason_counts": {
+        "not_emitted": 1
+      },
+      "dependence_skipped_lag_count": 0,
+      "dependence_skipped_lag_reason_counts": {},
+      "dependence_status_counts": {
+        "skipped": 1
+      },
       "dynamics_limitation_counts": {},
       "dynamics_reason_counts": {
         "microstructure_dynamics": {
@@ -293,6 +304,33 @@
           "applicable_dynamics_reason": "not_emitted",
           "applicable_dynamics_section": "return_dynamics",
           "applicable_dynamics_status": "skipped",
+          "dependence": {
+            "acf_basis": "unknown",
+            "basis": "unknown",
+            "cache_source": null,
+            "computed_from": "unknown",
+            "computed_lag_count": 0,
+            "included_lag_count": 0,
+            "invalid_row_count": 0,
+            "lag_count": 0,
+            "lags": [],
+            "lags_truncated": false,
+            "limitations": [],
+            "omitted_lag_count": 0,
+            "partial_row_count": 0,
+            "reason": "not_emitted",
+            "regular_grid": false,
+            "row_count": 0,
+            "row_order": "unknown",
+            "sampled_row_count": 0,
+            "series": {},
+            "series_count": 0,
+            "skipped_lag_count": 0,
+            "skipped_lag_reason_counts": {},
+            "status": "skipped",
+            "truncated": false,
+            "usable_row_count": 0
+          },
           "microstructure_dynamics": {
             "basis": "unknown",
             "cache_source": null,

--- a/tests/unit/test_data_quality_report_goldens.py
+++ b/tests/unit/test_data_quality_report_goldens.py
@@ -1339,6 +1339,13 @@ def _assert_fingerprint_readiness(payload: dict[str, JSONValue]) -> None:
         "applicable_dynamics_status_counts",
         "cache_source_counts",
         "computed_from_counts",
+        "dependence_acf_basis_counts",
+        "dependence_computed_lag_count",
+        "dependence_limitation_counts",
+        "dependence_reason_counts",
+        "dependence_skipped_lag_count",
+        "dependence_skipped_lag_reason_counts",
+        "dependence_status_counts",
         "dynamics_limitation_counts",
         "dynamics_reason_counts",
         "dynamics_status_counts",
@@ -1364,6 +1371,8 @@ def _assert_fingerprint_readiness(payload: dict[str, JSONValue]) -> None:
         "target_count",
         "included_target_count",
         "omitted_target_count",
+        "dependence_computed_lag_count",
+        "dependence_skipped_lag_count",
     ):
         assert isinstance(payload[key], int)
         assert payload[key] >= 0
@@ -1372,6 +1381,11 @@ def _assert_fingerprint_readiness(payload: dict[str, JSONValue]) -> None:
         "applicable_dynamics_status_counts",
         "cache_source_counts",
         "computed_from_counts",
+        "dependence_acf_basis_counts",
+        "dependence_limitation_counts",
+        "dependence_reason_counts",
+        "dependence_skipped_lag_reason_counts",
+        "dependence_status_counts",
         "dynamics_limitation_counts",
         "dynamics_reason_counts",
         "dynamics_status_counts",
@@ -1399,6 +1413,7 @@ def _assert_fingerprint_readiness_target(
         "applicable_dynamics_reason",
         "applicable_dynamics_section",
         "applicable_dynamics_status",
+        "dependence",
         "microstructure_dynamics",
         "profile_completeness",
         "return_dynamics",
@@ -1453,6 +1468,7 @@ def _assert_fingerprint_readiness_target(
     _assert_fingerprint_readiness_dynamics(
         _mapping(payload["microstructure_dynamics"])
     )
+    _assert_fingerprint_readiness_dependence(_mapping(payload["dependence"]))
 
 
 def _assert_fingerprint_readiness_topology(
@@ -1561,6 +1577,76 @@ def _assert_fingerprint_readiness_dynamics(
     ):
         if key in payload:
             assert isinstance(payload[key], dict)
+
+
+def _assert_fingerprint_readiness_dependence(
+    payload: dict[str, JSONValue],
+) -> None:
+    assert set(payload) == {
+        "acf_basis",
+        "basis",
+        "cache_source",
+        "computed_from",
+        "computed_lag_count",
+        "included_lag_count",
+        "invalid_row_count",
+        "lag_count",
+        "lags",
+        "lags_truncated",
+        "limitations",
+        "omitted_lag_count",
+        "partial_row_count",
+        "reason",
+        "regular_grid",
+        "row_count",
+        "row_order",
+        "sampled_row_count",
+        "series",
+        "series_count",
+        "skipped_lag_count",
+        "skipped_lag_reason_counts",
+        "status",
+        "truncated",
+        "usable_row_count",
+    }
+    assert payload["status"] in {"limited", "skipped", "unavailable", "valid"}
+    assert isinstance(payload["limitations"], list)
+    assert isinstance(payload["lags"], list)
+    assert isinstance(payload["lags_truncated"], bool)
+    assert isinstance(payload["regular_grid"], bool)
+    assert isinstance(payload["truncated"], bool)
+    assert isinstance(payload["skipped_lag_reason_counts"], dict)
+    for key in (
+        "computed_lag_count",
+        "included_lag_count",
+        "invalid_row_count",
+        "lag_count",
+        "omitted_lag_count",
+        "partial_row_count",
+        "row_count",
+        "sampled_row_count",
+        "series_count",
+        "skipped_lag_count",
+        "usable_row_count",
+    ):
+        assert isinstance(payload[key], int)
+    series = _mapping(payload["series"])
+    for summary in series.values():
+        _assert_fingerprint_readiness_acf_series(_mapping(summary))
+
+
+def _assert_fingerprint_readiness_acf_series(
+    payload: dict[str, JSONValue],
+) -> None:
+    assert set(payload) == {
+        "computed_lag_count",
+        "sample_count",
+        "skipped_lag_count",
+        "skipped_lag_reason_counts",
+    }
+    assert isinstance(payload["skipped_lag_reason_counts"], dict)
+    for key in ("computed_lag_count", "sample_count", "skipped_lag_count"):
+        assert isinstance(payload[key], int)
 
 
 def _assert_compact_numeric_summary(payload: dict[str, JSONValue]) -> None:

--- a/tests/unit/test_data_quality_reporting.py
+++ b/tests/unit/test_data_quality_reporting.py
@@ -468,6 +468,19 @@ def test_quality_report_payload_adds_fingerprint_readiness_metadata(
         "skipped": 2,
         "valid": 1,
     }
+    assert summary["dependence_status_counts"] == {
+        "limited": 1,
+        "valid": 2,
+    }
+    assert summary["dependence_reason_counts"] == {
+        "invalid_timestamps_skipped": 1,
+    }
+    assert summary["dependence_skipped_lag_reason_counts"] == {
+        "insufficient_sample_count": 4,
+        "zero_variance": 1,
+    }
+    assert summary["dependence_computed_lag_count"] == 17
+    assert summary["dependence_skipped_lag_count"] == 5
     assert summary["topology_limitation_counts"] == {
         "duplicate_timestamps": 1,
         "expected_session_closures": 1,
@@ -502,6 +515,22 @@ def test_quality_report_payload_adds_fingerprint_readiness_metadata(
         "suspicious_gaps",
         "expected_session_closures",
     ]
+    assert limited["dependence"]["status"] == "limited"
+    assert limited["dependence"]["reason"] == "invalid_timestamps_skipped"
+    assert limited["dependence"]["acf_basis"] == "observed_sequence"
+    assert limited["dependence"]["lags"] == [1, 3]
+    assert limited["dependence"]["computed_lag_count"] == 3
+    assert limited["dependence"]["skipped_lag_count"] == 5
+    assert limited["dependence"]["skipped_lag_reason_counts"] == {
+        "insufficient_sample_count": 4,
+        "zero_variance": 1,
+    }
+    assert limited["dependence"]["series"]["close_log_return_acf"] == {
+        "sample_count": 2,
+        "computed_lag_count": 1,
+        "skipped_lag_count": 1,
+        "skipped_lag_reason_counts": {"insufficient_sample_count": 1},
+    }
 
     tick = target_summaries[2]
     assert tick["applicable_dynamics_section"] == "microstructure_dynamics"
@@ -515,6 +544,8 @@ def test_quality_report_payload_adds_fingerprint_readiness_metadata(
         "ask_only_count": 1,
         "run_count": 0,
     }
+    assert tick["dependence"]["status"] == "valid"
+    assert tick["dependence"]["series"]["spread_acf"]["sample_count"] == 5
 
 
 def test_fingerprint_readiness_summary_handles_absent_dynamics_sections(
@@ -530,6 +561,11 @@ def test_fingerprint_readiness_summary_handles_absent_dynamics_sections(
 
     assert summary["applicable_dynamics_status_counts"] == {"skipped": 2}
     assert summary["dynamics_reason_counts"]["return_dynamics"] == {
+        "not_emitted": 1,
+        "unsupported_target_kind": 1,
+    }
+    assert summary["dependence_status_counts"] == {"skipped": 2}
+    assert summary["dependence_reason_counts"] == {
         "not_emitted": 1,
         "unsupported_target_kind": 1,
     }
@@ -550,6 +586,7 @@ def test_fingerprint_readiness_summary_handles_absent_dynamics_sections(
         "partial_row_count": 0,
         "truncated": False,
     }
+    assert target["dependence"] == _empty_dependence_summary("not_emitted")
 
 
 def test_fingerprint_console_summary_reports_readiness_lines(
@@ -569,7 +606,18 @@ def test_fingerprint_console_summary_reports_readiness_lines(
         "reasons: invalid_timestamps_skipped=1, unsupported_timeframe=1"
     ) in output
     assert (
+        "- dependence: limited=1, valid=2 reasons: "
+        "invalid_timestamps_skipped=1 skipped-lag reasons: "
+        "insufficient_sample_count=4, zero_variance=1 "
+        "acf_basis: observed_sequence=3 computed_lags=17 skipped_lags=5"
+    ) in output
+    assert (
         "- topology limitations: duplicate_timestamps=1, "
+        "expected_session_closures=1, invalid_timestamps_skipped=1, "
+        "non_monotonic_timestamp_order=1, suspicious_gaps=1"
+    ) in output
+    assert (
+        "- dependence limitations: duplicate_timestamps=1, "
         "expected_session_closures=1, invalid_timestamps_skipped=1, "
         "non_monotonic_timestamp_order=1, suspicious_gaps=1"
     ) in output
@@ -583,6 +631,13 @@ def test_fingerprint_console_summary_reports_readiness_lines(
         in output
     )
     assert "close_returns=3 median=0.0001" in output
+    assert (
+        "dependence=limited reason=invalid_timestamps_skipped "
+        "acf_basis=observed_sequence lags=[1,3] computed_lags=3 "
+        "skipped_lags=5 skipped_reasons=insufficient_sample_count=4, "
+        "zero_variance=1"
+    ) in output
+    assert "close_log_return_acf:samples=2/computed=1/skipped=1" in output
     assert (
         "- ascii EURUSD T 201202 csv: microstructure_dynamics valid"
     ) in output
@@ -1220,6 +1275,71 @@ def test_fingerprint_readiness_summary_is_bounded_and_issue_first(
     )
 
 
+def test_fingerprint_readiness_summary_orders_limited_dependence_first(
+    tmp_path: Path,
+) -> None:
+    """Bounded readiness summaries should prioritize dependence limitations."""
+    limited_target = QualityTarget(
+        path=str(tmp_path / "limited-dependence.csv"),
+        kind=QualityTargetKind.CSV,
+        data_format="ascii",
+        timeframe="M1",
+        symbol="AUDUSD",
+        period="201202",
+    )
+    valid_target = QualityTarget(
+        path=str(tmp_path / "valid-dependence.csv"),
+        kind=QualityTargetKind.CSV,
+        data_format="ascii",
+        timeframe="M1",
+        symbol="EURUSD",
+        period="201202",
+    )
+    limited_payload = _valid_m1_fingerprint_payload(kind="csv")
+    axis = limited_payload["target_axis"]
+    assert isinstance(axis, dict)
+    axis["symbol"] = "AUDUSD"
+    axis["kind"] = "csv"
+    limited_payload["dependence"] = _dependence_payload(
+        status="limited",
+        reason="skipped_lags",
+        row_count=4,
+        sampled_row_count=4,
+        usable_row_count=4,
+        series={
+            "close_log_return_acf": _acf_payload(
+                sample_count=2,
+                computed=1,
+                skipped={"3": "insufficient_sample_count"},
+            )
+        },
+    )
+    audit = limited_payload["fingerprint_audit"]
+    assert isinstance(audit, dict)
+    section_statuses = audit["section_statuses"]
+    assert isinstance(section_statuses, dict)
+    section_statuses["dependence"] = "limited"
+    valid_payload = _valid_m1_fingerprint_payload(kind="csv")
+
+    summary = series_fingerprint_readiness_summary(
+        (
+            _fingerprint_series_finding(valid_target, valid_payload),
+            _fingerprint_series_finding(limited_target, limited_payload),
+        ),
+        target_limit=1,
+    )
+
+    assert summary is not None
+    assert summary["target_count"] == 2
+    assert summary["included_target_count"] == 1
+    assert summary["omitted_target_count"] == 1
+    assert summary["target_summaries"][0]["target_axis"]["symbol"] == "AUDUSD"
+    assert summary["target_summaries"][0]["applicable_dynamics_status"] == (
+        "valid"
+    )
+    assert summary["target_summaries"][0]["dependence"]["status"] == "limited"
+
+
 def test_bounded_quality_payload_includes_next_actions(
     tmp_path: Path,
 ) -> None:
@@ -1682,6 +1802,24 @@ def _valid_m1_fingerprint_payload(*, kind: str) -> dict[str, object]:
                 "ohlc_flatline_affected_row_count": 0,
             },
         },
+        "dependence": _dependence_payload(
+            status="ok",
+            row_order="cache_order",
+            computed_from="direct_cache",
+            cache_source="direct",
+            row_count=4,
+            sampled_row_count=4,
+            usable_row_count=4,
+            series={
+                "absolute_return_acf": _acf_payload(sample_count=3, computed=2),
+                "close_log_return_acf": _acf_payload(
+                    sample_count=3,
+                    computed=2,
+                ),
+                "range_ratio_acf": _acf_payload(sample_count=4, computed=2),
+                "squared_return_acf": _acf_payload(sample_count=3, computed=2),
+            },
+        ),
         "fingerprint_audit": _audit_payload(
             expected=(
                 "coverage",
@@ -1689,12 +1827,14 @@ def _valid_m1_fingerprint_payload(*, kind: str) -> dict[str, object]:
                 "calendar_regimes",
                 "m1_bar_distribution",
                 "return_dynamics",
+                "dependence",
             ),
             emitted=(
                 "coverage",
                 "temporal_topology",
                 "m1_bar_distribution",
                 "return_dynamics",
+                "dependence",
             ),
             skipped={"calendar_regimes": "not_emitted"},
             section_statuses={
@@ -1703,6 +1843,7 @@ def _valid_m1_fingerprint_payload(*, kind: str) -> dict[str, object]:
                 "calendar_regimes": "skipped",
                 "m1_bar_distribution": "valid",
                 "return_dynamics": "valid",
+                "dependence": "valid",
             },
             return_status="valid",
             micro_status="skipped",
@@ -1765,6 +1906,42 @@ def _limited_m1_fingerprint_payload() -> dict[str, object]:
                 "ohlc_flatline_affected_row_count": 2,
             },
         },
+        "dependence": _dependence_payload(
+            status="limited",
+            reason="invalid_timestamps_skipped",
+            limitations=tuple(limitations),
+            row_count=4,
+            sampled_row_count=3,
+            usable_row_count=3,
+            invalid_row_count=1,
+            partial_row_count=1,
+            truncated=True,
+            series={
+                "absolute_return_acf": _acf_payload(
+                    sample_count=3,
+                    computed=1,
+                    skipped={"3": "insufficient_sample_count"},
+                ),
+                "close_log_return_acf": _acf_payload(
+                    sample_count=2,
+                    computed=1,
+                    skipped={"3": "insufficient_sample_count"},
+                ),
+                "range_ratio_acf": _acf_payload(
+                    sample_count=3,
+                    computed=1,
+                    skipped={"3": "insufficient_sample_count"},
+                ),
+                "squared_return_acf": _acf_payload(
+                    sample_count=3,
+                    computed=0,
+                    skipped={
+                        "1": "zero_variance",
+                        "3": "insufficient_sample_count",
+                    },
+                ),
+            },
+        ),
         "fingerprint_audit": _audit_payload(
             expected=(
                 "coverage",
@@ -1772,12 +1949,14 @@ def _limited_m1_fingerprint_payload() -> dict[str, object]:
                 "calendar_regimes",
                 "m1_bar_distribution",
                 "return_dynamics",
+                "dependence",
             ),
             emitted=(
                 "coverage",
                 "temporal_topology",
                 "m1_bar_distribution",
                 "return_dynamics",
+                "dependence",
             ),
             skipped={"calendar_regimes": "not_emitted"},
             section_statuses={
@@ -1786,6 +1965,7 @@ def _limited_m1_fingerprint_payload() -> dict[str, object]:
                 "calendar_regimes": "skipped",
                 "m1_bar_distribution": "valid",
                 "return_dynamics": "limited",
+                "dependence": "limited",
             },
             return_status="limited",
             return_reason="invalid_timestamps_skipped",
@@ -1861,6 +2041,21 @@ def _tick_fingerprint_payload() -> dict[str, object]:
                 "run_count": 0,
             },
         },
+        "dependence": _dependence_payload(
+            status="ok",
+            lags=(1, 2),
+            row_count=5,
+            sampled_row_count=5,
+            usable_row_count=5,
+            series={
+                "absolute_spread_change_acf": _acf_payload(
+                    sample_count=4,
+                    computed=2,
+                ),
+                "spread_acf": _acf_payload(sample_count=5, computed=2),
+                "spread_change_acf": _acf_payload(sample_count=4, computed=2),
+            },
+        ),
         "fingerprint_audit": _audit_payload(
             expected=(
                 "coverage",
@@ -1869,6 +2064,7 @@ def _tick_fingerprint_payload() -> dict[str, object]:
                 "tick_distribution",
                 "conditional_distributions",
                 "microstructure_dynamics",
+                "dependence",
             ),
             emitted=(
                 "coverage",
@@ -1876,6 +2072,7 @@ def _tick_fingerprint_payload() -> dict[str, object]:
                 "tick_distribution",
                 "conditional_distributions",
                 "microstructure_dynamics",
+                "dependence",
             ),
             skipped={"calendar_regimes": "not_emitted"},
             section_statuses={
@@ -1885,6 +2082,7 @@ def _tick_fingerprint_payload() -> dict[str, object]:
                 "tick_distribution": "valid",
                 "conditional_distributions": "valid",
                 "microstructure_dynamics": "valid",
+                "dependence": "valid",
             },
             return_status="skipped",
             return_reason="unsupported_timeframe",
@@ -2010,6 +2208,103 @@ def _audit_payload(
                 usable_row_count=5 if micro_status == "valid" else 0,
             ),
         },
+    }
+
+
+def _dependence_payload(
+    *,
+    status: str,
+    reason: str | None = None,
+    lags: tuple[int, ...] = (1, 3),
+    row_order: str = "source_text_order",
+    computed_from: str = "text_scan",
+    cache_source: str | None = None,
+    limitations: tuple[str, ...] = (),
+    row_count: int,
+    sampled_row_count: int,
+    usable_row_count: int,
+    invalid_row_count: int = 0,
+    partial_row_count: int = 0,
+    truncated: bool = False,
+    series: dict[str, dict[str, object]],
+) -> dict[str, object]:
+    computed_lag_count = sum(
+        int(item["computed_lag_count"]) for item in series.values()
+    )
+    skipped_lag_count = sum(
+        int(item["skipped_lag_count"]) for item in series.values()
+    )
+    payload: dict[str, object] = {
+        "basis": "observed_sequence",
+        "acf_basis": "observed_sequence",
+        "row_order": row_order,
+        "computed_from": computed_from,
+        "cache_source": cache_source,
+        "regular_grid": False,
+        "dependence_status": status,
+        "limitations": list(limitations),
+        "row_count": row_count,
+        "sampled_row_count": sampled_row_count,
+        "usable_row_count": usable_row_count,
+        "invalid_row_count": invalid_row_count,
+        "partial_row_count": partial_row_count,
+        "truncated": truncated,
+        "lags": list(lags),
+        "computed_lag_count": computed_lag_count,
+        "skipped_lag_count": skipped_lag_count,
+    }
+    if reason:
+        payload["reason"] = reason
+    payload.update(series)
+    return payload
+
+
+def _acf_payload(
+    *,
+    sample_count: int,
+    computed: int,
+    skipped: dict[str, str] | None = None,
+) -> dict[str, object]:
+    skipped = skipped or {}
+    return {
+        "sample_count": sample_count,
+        "lag_acf": {str(index + 1): 0.0 for index in range(computed)},
+        "computed_lag_count": computed,
+        "skipped_lags": {
+            lag: {"reason": reason, "sample_count": sample_count}
+            for lag, reason in skipped.items()
+        },
+        "skipped_lag_count": len(skipped),
+    }
+
+
+def _empty_dependence_summary(reason: str) -> dict[str, object]:
+    return {
+        "status": "skipped",
+        "reason": reason,
+        "basis": "unknown",
+        "acf_basis": "unknown",
+        "row_order": "unknown",
+        "computed_from": "unknown",
+        "cache_source": None,
+        "regular_grid": False,
+        "limitations": [],
+        "row_count": 0,
+        "sampled_row_count": 0,
+        "usable_row_count": 0,
+        "invalid_row_count": 0,
+        "partial_row_count": 0,
+        "truncated": False,
+        "lag_count": 0,
+        "lags": [],
+        "included_lag_count": 0,
+        "omitted_lag_count": 0,
+        "lags_truncated": False,
+        "computed_lag_count": 0,
+        "skipped_lag_count": 0,
+        "skipped_lag_reason_counts": {},
+        "series_count": 0,
+        "series": {},
     }
 
 


### PR DESCRIPTION
Closes #388

## Summary
- Add bounded dependence readiness metadata to the series fingerprint readiness summary.
- Render dependence status, reasons, ACF basis, lag counts, skipped-lag reasons, limitations, and per-series counts in quality report output.
- Update README coverage, report golden fixtures, and reporting tests for full/limited/missing dependence payloads.

## Validation
- `python3 -m pytest tests/unit/test_data_quality_reporting.py -q` (42 passed)
- `python3 -m pytest tests/unit/test_data_quality_report_goldens.py -q` (10 passed after fixture regeneration)
- `python3 -m pytest tests/unit/test_data_quality_fingerprints.py tests/unit/test_data_quality_fingerprint_discovery.py tests/unit/test_data_quality_reporting.py tests/unit/test_data_quality_report_goldens.py -q` (90 passed)
- `python3 -m pre_commit run --all-files` (passed)
- `python3 -m pytest` (1315 passed)

## Notes
- This is intentionally report/rendering work. It does not alter the raw time-series fingerprint schema or dependence calculation semantics.