### PR TITLE
[codex] feat(data-quality): render fingerprint surface evidence table

### DIFF
--- a/README.md
+++ b/README.md
@@ -1075,6 +1075,12 @@ quality rules, or automate GitHub/CI/release workflow. Cache-scale
 `--quality-preflight` runs the same contract audit automatically and fails its
 readiness decision when the audit reports contract errors.
 
+The human `histdatacom quality fingerprint-schema --verify` output and
+quality-preflight Markdown report include a bounded report-surface evidence
+table, so operators can see the representative surface key, summary schema key,
+full-report metadata state, bounded-payload state, CLI/report heading state, and
+intentional CLI absence reason without inspecting nested JSON.
+
 Run the bounded report-payload contract self-audit when changing report
 summaries, bounded payloads, next actions, remediation coverage, remediation
 catalog audits, or fingerprint summary surfaces:

--- a/src/histdatacom/data_quality/fingerprint_discovery.py
+++ b/src/histdatacom/data_quality/fingerprint_discovery.py
@@ -59,6 +59,15 @@ TIME_SERIES_FINGERPRINT_CONTRACT_AUDIT_SCHEMA_VERSION = (
 TIME_SERIES_FINGERPRINT_REPORT_SURFACE_EVIDENCE_SCHEMA_VERSION = (
     "histdatacom.time-series-fingerprint-report-surface-evidence.v1"
 )
+FINGERPRINT_REPORT_SURFACE_EVIDENCE_TABLE_HEADERS = (
+    "surface key",
+    "summary schema key",
+    "report metadata",
+    "bounded payload",
+    "CLI/report summary",
+    "intentional absence",
+)
+FINGERPRINT_REPORT_SURFACE_EVIDENCE_DISPLAY_LIMIT = 12
 
 
 def fingerprint_schema_discovery(
@@ -386,6 +395,20 @@ def format_fingerprint_contract_audit(
             f"- {check.get('name', '')}: {check.get('status', '')} "
             f"({check.get('checked_count', 0)} checked)"
         )
+    evidence_rows = fingerprint_report_surface_evidence_table_rows(
+        _mapping(payload.get("report_surface_evidence"))
+    )
+    if evidence_rows:
+        lines.extend(
+            [
+                "",
+                "Report Surface Evidence",
+                *_plain_text_table(
+                    FINGERPRINT_REPORT_SURFACE_EVIDENCE_TABLE_HEADERS,
+                    evidence_rows,
+                ),
+            ]
+        )
     findings = _mapping_rows(payload.get("findings"))
     if findings:
         lines.extend(["", "Findings"])
@@ -399,6 +422,73 @@ def format_fingerprint_contract_audit(
     else:
         lines.extend(["", "No contract drift detected."])
     return "\n".join(lines)
+
+
+def fingerprint_report_surface_evidence_table_rows(
+    evidence: Mapping[str, JSONValue],
+    *,
+    limit: int = FINGERPRINT_REPORT_SURFACE_EVIDENCE_DISPLAY_LIMIT,
+) -> tuple[tuple[str, str, str, str, str, str], ...]:
+    """Return bounded display rows for representative report-surface evidence."""
+    rows: list[tuple[str, str, str, str, str, str]] = []
+    surface_rows = _mapping_rows(evidence.get("surface_matrix"))
+    display_limit = max(0, limit)
+    for row in surface_rows[:display_limit]:
+        rows.append(_report_surface_evidence_table_row(row))
+    omitted = len(surface_rows) - len(rows)
+    if omitted > 0:
+        rows.append(
+            (
+                f"{omitted} additional surfaces omitted",
+                "",
+                "",
+                "",
+                "",
+                "",
+            )
+        )
+    return tuple(rows)
+
+
+def _report_surface_evidence_table_row(
+    row: Mapping[str, JSONValue],
+) -> tuple[str, str, str, str, str, str]:
+    heading = str(row.get("cli_summary_heading") or "")
+    cli_state = str(row.get("cli_summary_state") or "")
+    cli_display = f"{cli_state} ({heading})" if heading else cli_state
+    return (
+        str(row.get("key") or ""),
+        str(row.get("summary_schema_key") or ""),
+        str(row.get("report_metadata_state") or ""),
+        str(row.get("bounded_payload_state") or ""),
+        cli_display,
+        str(row.get("intentional_absence_reason") or ""),
+    )
+
+
+def _plain_text_table(
+    headers: tuple[str, ...],
+    rows: tuple[tuple[str, ...], ...],
+) -> list[str]:
+    widths = [
+        max(len(header), *(len(row[index]) for row in rows))
+        for index, header in enumerate(headers)
+    ]
+    lines = [
+        "  "
+        + " | ".join(
+            header.ljust(widths[index]) for index, header in enumerate(headers)
+        ),
+        "  " + "-+-".join("-" * width for width in widths),
+    ]
+    for row in rows:
+        lines.append(
+            "  "
+            + " | ".join(
+                row[index].ljust(widths[index]) for index in range(len(headers))
+            )
+        )
+    return lines
 
 
 def _record_audit_check(

--- a/src/histdatacom/data_quality/preflight.py
+++ b/src/histdatacom/data_quality/preflight.py
@@ -32,7 +32,9 @@ from histdatacom.data_quality.discovery import (
 )
 from histdatacom.data_quality.engine import run_quality_assessment
 from histdatacom.data_quality.fingerprint_discovery import (
+    FINGERPRINT_REPORT_SURFACE_EVIDENCE_TABLE_HEADERS,
     fingerprint_contract_audit,
+    fingerprint_report_surface_evidence_table_rows,
 )
 from histdatacom.data_quality.polars_cache import read_quality_polars_cache
 from histdatacom.data_quality.rules import (
@@ -489,6 +491,21 @@ def quality_preflight_to_markdown(payload: Mapping[str, JSONValue]) -> str:
             "",
         ]
     )
+    surface_rows = fingerprint_report_surface_evidence_table_rows(
+        _mapping(fingerprint_contract.get("report_surface_evidence"))
+    )
+    if surface_rows:
+        lines.extend(
+            [
+                "### Fingerprint Report Surface Evidence",
+                "",
+                *_markdown_table(
+                    FINGERPRINT_REPORT_SURFACE_EVIDENCE_TABLE_HEADERS,
+                    surface_rows,
+                ),
+                "",
+            ]
+        )
     finding_rows = _fingerprint_contract_finding_rows(fingerprint_contract)
     if finding_rows:
         lines.extend(

--- a/tests/unit/test_data_quality_fingerprint_discovery.py
+++ b/tests/unit/test_data_quality_fingerprint_discovery.py
@@ -347,7 +347,43 @@ def test_format_fingerprint_contract_audit_renders_human_summary() -> None:
     assert output.startswith("Fingerprint Contract Audit\n")
     assert "status: pass" in output
     assert "- schema_contracts: pass" in output
+    assert "Report Surface Evidence" in output
+    assert "coverage_summary" in output
+    assert "present (Fingerprint coverage)" in output
+    assert "regime_summary" in output
+    assert "present (Fingerprint regimes)" in output
     assert "No contract drift detected." in output
+
+
+def test_format_fingerprint_contract_audit_renders_intentional_absence() -> (
+    None
+):
+    """Human audit output should explain intentionally absent CLI surfaces."""
+    contract = FingerprintReportSurfaceContract(
+        key="readiness_api_only",
+        summary_schema_key="fingerprint_readiness_summary",
+        report_metadata_key="time_series_fingerprint_readiness_summary",
+        bounded_payload_key="fingerprint_readiness",
+        cli_summary_section="",
+        cli_summary_heading="",
+        intentional_absence_reason="covered by machine-readable API only",
+    )
+    evidence = fingerprint_report_surface_evidence(contracts=(contract,))
+    payload = {
+        "schema_version": TIME_SERIES_FINGERPRINT_CONTRACT_AUDIT_SCHEMA_VERSION,
+        "status": "pass",
+        "error_count": 0,
+        "warning_count": 0,
+        "checks": [],
+        "findings": [],
+        "report_surface_evidence": evidence,
+    }
+
+    output = format_fingerprint_contract_audit(payload)
+
+    assert "readiness_api_only" in output
+    assert "intentionally_absent" in output
+    assert "covered by machine-readable API only" in output
 
 
 def test_fingerprint_schema_discovery_reflects_profile_overrides() -> None:

--- a/tests/unit/test_data_quality_preflight.py
+++ b/tests/unit/test_data_quality_preflight.py
@@ -16,6 +16,13 @@ import pytest
 
 from histdatacom import Options
 from histdatacom.cli import ArgParser
+from histdatacom.data_quality.fingerprint_contracts import (
+    FingerprintReportSurfaceContract,
+)
+from histdatacom.data_quality.fingerprint_discovery import (
+    TIME_SERIES_FINGERPRINT_CONTRACT_AUDIT_SCHEMA_VERSION,
+    fingerprint_report_surface_evidence,
+)
 from histdatacom.data_quality.preflight import (
     DEFAULT_QUALITY_PREFLIGHT_VALIDATION_REPORT_DIR,
     QUALITY_PREFLIGHT_SCHEMA_VERSION,
@@ -186,12 +193,60 @@ def test_quality_preflight_surfaces_fingerprint_contract_audit(
     assert "bounded payload contract audit: pass" in console
     assert "policy=fail-preflight-on-error" in console
     assert "## Fingerprint Contract Audit" in markdown
+    assert "### Fingerprint Report Surface Evidence" in markdown
+    assert "coverage_summary" in markdown
+    assert "regime_summary" in markdown
+    assert "present (Fingerprint regimes)" in markdown
     assert "## Bounded Payload Contract Audit" in markdown
     assert "| Status | pass |" in markdown
     assert "histdatacom quality fingerprint-schema --verify --json" in markdown
     assert "histdatacom quality bounded-payload-contract --json" in markdown
     assert str(tmp_path) not in json.dumps(payload, sort_keys=True)
     assert str(tmp_path) not in markdown
+
+
+def test_quality_preflight_markdown_renders_intentional_cli_absence() -> None:
+    """Markdown evidence should explain intentionally absent CLI surfaces."""
+    contract = FingerprintReportSurfaceContract(
+        key="readiness_api_only",
+        summary_schema_key="fingerprint_readiness_summary",
+        report_metadata_key="time_series_fingerprint_readiness_summary",
+        bounded_payload_key="fingerprint_readiness",
+        cli_summary_section="",
+        cli_summary_heading="",
+        intentional_absence_reason="covered by machine-readable API only",
+    )
+    evidence = fingerprint_report_surface_evidence(contracts=(contract,))
+    payload = {
+        "schema_version": QUALITY_PREFLIGHT_SCHEMA_VERSION,
+        "evidence": {
+            "fingerprint_contract_audit": {
+                "schema_version": (
+                    TIME_SERIES_FINGERPRINT_CONTRACT_AUDIT_SCHEMA_VERSION
+                ),
+                "status": "pass",
+                "check_count": 0,
+                "finding_count": 0,
+                "error_count": 0,
+                "warning_count": 0,
+                "preflight_status_policy": "fail-preflight-on-error",
+                "preflight_gate": {
+                    "reason": "fingerprint contract audit passed",
+                    "standalone_command": (
+                        "histdatacom quality fingerprint-schema --verify --json"
+                    ),
+                },
+                "report_surface_evidence": evidence,
+            }
+        },
+    }
+
+    markdown = quality_preflight_to_markdown(payload)
+
+    assert "### Fingerprint Report Surface Evidence" in markdown
+    assert "readiness_api_only" in markdown
+    assert "intentionally_absent" in markdown
+    assert "covered by machine-readable API only" in markdown
 
 
 def test_quality_preflight_fails_on_fingerprint_contract_drift(


### PR DESCRIPTION
## Summary

- Render the existing fingerprint `report_surface_evidence.surface_matrix` as a bounded human-readable table in `histdatacom quality fingerprint-schema --verify`.
- Add the same report-surface evidence table to quality-preflight Markdown output.
- Cover fully present surfaces, the `regime_summary` / `Fingerprint regimes` row, and intentionally absent CLI/report surfaces in tests.
- Document the new human/Markdown evidence surface in the README.

## Validation

- `python -m histdatacom quality fingerprint-schema --verify`
- `python -m pytest tests/unit/test_data_quality_fingerprint_discovery.py tests/unit/test_data_quality_preflight.py -q`
- `python -m pytest tests/unit/test_quality_cli.py -q`
- `python -m pytest` passed: 1,354 tests
- `python -m pre_commit run --all-files`
- commit and pre-push hooks, including coverage, passed
- GitHub Actions for PR #405 passed, including build artifacts, dependency audit/review, CodeQL, workflow lint, smoke wheels, and the Python 3.10/3.11/3.12/3.13 matrix on Ubuntu/macOS/Windows

Closes #404